### PR TITLE
Make superdumpservice start up under linux (first step)

### DIFF
--- a/build/runsuperdump.cmd
+++ b/build/runsuperdump.cmd
@@ -10,4 +10,4 @@ REM a working symbolpath with three servers can work like that: _NT_SYMBOL_PATH=
 set _NT_SYMBOL_PATH=srv*c:\symbols*https://msdl.microsoft.com/download/symbols
 
 cd bin\SuperDumpService
-call SuperDumpService.exe
+call dotnet SuperDumpService.dll

--- a/conf/appsettings.json
+++ b/conf/appsettings.json
@@ -1,4 +1,5 @@
 ﻿{
+	"UseInMemoryHangfireStorage": "false", // true, if you want to run under linux
 	"ConnectionStrings": {
 		"HangfireDB": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=Hangfire;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=True;ApplicationIntent=ReadWrite;MultiSubnetFailover=False;"
 	},

--- a/src/SuperDumpService/Helpers/PathHelper.cs
+++ b/src/SuperDumpService/Helpers/PathHelper.cs
@@ -3,10 +3,10 @@ using System.IO;
 
 namespace SuperDumpService.Helpers {
 	public static class PathHelper {
-		private static string workingDir = Path.Combine(Directory.GetCurrentDirectory(), @"..\..\data\dumps\");
-		private static string uploadsDir = Path.Combine(Directory.GetCurrentDirectory(), @"..\..\data\uploads\");
-		private static string hangfireDbDir = Path.Combine(Directory.GetCurrentDirectory(), @"..\..\data\hangfire\");
-		private static string confDir = Path.Combine(Directory.GetCurrentDirectory(), @"..\..\conf\");
+		private static string workingDir = Path.Combine(Directory.GetCurrentDirectory(), @"../../data/dumps/");
+		private static string uploadsDir = Path.Combine(Directory.GetCurrentDirectory(), @"../../data/uploads/");
+		private static string hangfireDbDir = Path.Combine(Directory.GetCurrentDirectory(), @"../../data/hangfire/");
+		private static string confDir = Path.Combine(Directory.GetCurrentDirectory(), @"../../conf/");
 
 		internal static string GetHangfireDBDir() {
 			return hangfireDbDir;

--- a/src/SuperDumpService/Properties/PublishProfiles/publish-profile.pubxml
+++ b/src/SuperDumpService/Properties/PublishProfiles/publish-profile.pubxml
@@ -12,9 +12,9 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <SiteUrlToLaunchAfterPublish />
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
     <ExcludeApp_Data>False</ExcludeApp_Data>
-    <PublishFramework>net46</PublishFramework>
+    <PublishFramework>netcoreapp1.1</PublishFramework>
     <ProjectGuid>f362a805-cad7-44a5-a6e3-6f69dd429c8e</ProjectGuid>
     <publishUrl>..\..\build\bin\SuperDumpService</publishUrl>
-    <DeleteExistingFiles>True</DeleteExistingFiles>
+    <DeleteExistingFiles>False</DeleteExistingFiles>
   </PropertyGroup>
 </Project>

--- a/src/SuperDumpService/Services/BundleStorageFilebased.cs
+++ b/src/SuperDumpService/Services/BundleStorageFilebased.cs
@@ -20,6 +20,7 @@ namespace SuperDumpService.Services {
 		}
 
 		public IEnumerable<BundleMetainfo> ReadBundleMetainfos() {
+			PathHelper.PrepareDirectories();
 			foreach (var dir in Directory.EnumerateDirectories(PathHelper.GetWorkingDir())) {
 				var bundleId = new DirectoryInfo(dir).Name;
 				var metainfoFilename = PathHelper.GetBundleMetadataPath(bundleId);

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -39,17 +39,23 @@ namespace SuperDumpService {
 			IEnumerable<int> test = new List<int>();
 
 			//configure DB
-			string connString;
-			Console.WriteLine(Directory.GetCurrentDirectory());
-			using (SqlConnection conn = LocalDBAccess.GetLocalDB("HangfireDB")) {
-				connString = conn.ConnectionString;
+			if (Configuration.GetValue<bool>("UseInMemoryHangfireStorage")) {
+				services.AddHangfire(x => x.UseStorage(new Hangfire.MemoryStorage.MemoryStorage()));
+			} else {
+				string connString;
+				Console.WriteLine(Directory.GetCurrentDirectory());
+				using (SqlConnection conn = LocalDBAccess.GetLocalDB("HangfireDB")) {
+					connString = conn.ConnectionString;
+				}
+				if (string.IsNullOrEmpty(connString)) {
+					throw new Exception("DB could not be created, please check if LocalDB is installed.");
+				}
+				services.AddHangfire(x => x.UseSqlServerStorage(connString));
 			}
-			if (string.IsNullOrEmpty(connString)) {
-				throw new Exception("DB could not be created, please check if LocalDB is installed.");
-			}
+
+			// set upload limit
 			services.Configure<FormOptions>(opt => opt.MultipartBodyLengthLimit = 16L * 1024 * 1024 * 1024); // 16GB
 
-			services.AddHangfire(x => x.UseSqlServerStorage(connString));
 			// Add framework services.
 			services.AddMvc();
 			//services.AddCors();
@@ -68,7 +74,10 @@ namespace SuperDumpService {
 				var basePath = PlatformServices.Default.Application.ApplicationBasePath;
 
 				//Set the comments path for the swagger json and ui.
-				options.IncludeXmlComments(basePath + "\\SuperDumpService.xml");
+				var xmlDocFile = new FileInfo(Path.Combine(basePath, "SuperDumpService.xml"));
+				if (xmlDocFile.Exists) {
+					options.IncludeXmlComments(xmlDocFile.FullName);
+				}
 			});
 
 			// register repository as singleton

--- a/src/SuperDumpService/SuperDumpService.csproj
+++ b/src/SuperDumpService/SuperDumpService.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+    <RuntimeIdentifiers>win7-x64;linux-x64</RuntimeIdentifiers>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PreserveCompilationContext>true</PreserveCompilationContext>
@@ -21,6 +21,7 @@
     <PackageReference Include="ByteSize" Version="1.3.0" />
     <PackageReference Include="Hangfire" Version="1.6.8" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.6.8" />
+    <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.0" />


### PR DESCRIPTION
In order to make SuperDumpService run under linux, I did this:
 * change hangfire-storage to in-memory (optionally)
 * include "linux-64" in RuntimeIdentifiers
 * fix a few path related problems

What's not working:
 * Dump-download via api did not quite work yet.
 * The whole analysis of course. This will be a larger project...