### PR TITLE
Coredump support

### DIFF
--- a/conf/appsettings.json
+++ b/conf/appsettings.json
@@ -24,7 +24,8 @@
 		//"SuperDumpSelectorExePath": "../../SuperDumpSelector/SuperDumpSelector.exe",
 		"DeleteDumpAfterAnalysis": "false",
 		"DumpDownloadable": "true",
-		"MaxUploadSizeMB": "16000"
+		"MaxUploadSizeMB": "16000",
+		"IncludeOtherFilesInReport": "true" // if true, sibling files to a crashdump within a zip-file are copied to the dump-report directory.
 	},
 	"ApplicationInsights": {
 		"InstrumentationKey": "-"

--- a/conf/appsettings.json
+++ b/conf/appsettings.json
@@ -25,7 +25,8 @@
 		"DeleteDumpAfterAnalysis": "false",
 		"DumpDownloadable": "true",
 		"MaxUploadSizeMB": "16000",
-		"IncludeOtherFilesInReport": "true" // if true, sibling files to a crashdump within a zip-file are copied to the dump-report directory.
+		"IncludeOtherFilesInReport": "true", // if true, sibling files to a crashdump within a zip-file are copied to the dump-report directory.
+		"LinuxCommandTemplate": "myanalysis.sh {coredump} {outputjson}"
 	},
 	"ApplicationInsights": {
 		"InstrumentationKey": "-"

--- a/src/SuperDump.sln
+++ b/src/SuperDump.sln
@@ -17,7 +17,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SuperDumpSelector", "SuperD
 		{0DD4DA67-4E55-4EE1-9030-5A69D8CDC6B4} = {0DD4DA67-4E55-4EE1-9030-5A69D8CDC6B4}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SuperDumpModels", "SuperDumpmodels\SuperDumpModels.csproj", "{BB6EC51D-3ACC-4ADE-B09C-4217B4AD3C58}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SuperDumpModels", "SuperDumpModels\SuperDumpModels.csproj", "{BB6EC51D-3ACC-4ADE-B09C-4217B4AD3C58}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SuperDumpService", "SuperDumpService\SuperDumpService.csproj", "{F362A805-CAD7-44A5-A6E3-6F69DD429C8E}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/src/SuperDump/Program.cs
+++ b/src/SuperDump/Program.cs
@@ -9,6 +9,7 @@ using SuperDump.Printers;
 namespace SuperDump {
 	public static class Program {
 		public static string DUMP_LOC;
+		private static string OUTPUT_LOC;
 		public static string SYMBOL_PATH = Environment.GetEnvironmentVariable("_NT_SYMBOL_PATH");
 
 		private static DumpContext context;
@@ -30,10 +31,17 @@ namespace SuperDump {
 					DUMP_LOC = args[0];
 				}
 
+				if (args.Length < 2) {
+					Console.WriteLine("no output file was specified! Please enter output file: ");
+					OUTPUT_LOC = Console.ReadLine();
+				} else {
+					OUTPUT_LOC = args[1];
+				}
+
 				string absoluteDumpFile = Path.GetFullPath(DUMP_LOC);
 
 				Console.WriteLine(absoluteDumpFile);
-				context.Printer = new FilePrinter(absoluteDumpFile + ".log");
+				context.Printer = new FilePrinter("superdump.log");
 
 				try {
 					if (File.Exists(absoluteDumpFile)) {
@@ -91,8 +99,7 @@ namespace SuperDump {
 						analyzer.PrintExceptionsObjects();
 
 						// write to json
-						analysisResult.WriteResultToJSONFile(context.DumpDirectory + "\\" +
-							 Path.GetFileNameWithoutExtension(context.DumpFile) + ".json");
+						analysisResult.WriteResultToJSONFile(OUTPUT_LOC);
 
 						context.WriteInfo("--- End of output ---");
 						Console.WriteLine("done.");

--- a/src/SuperDump/Program.cs
+++ b/src/SuperDump/Program.cs
@@ -39,9 +39,10 @@ namespace SuperDump {
 				}
 
 				string absoluteDumpFile = Path.GetFullPath(DUMP_LOC);
-
 				Console.WriteLine(absoluteDumpFile);
-				context.Printer = new FilePrinter("superdump.log");
+
+				var logfile = new FileInfo(Path.Combine(Path.GetDirectoryName(OUTPUT_LOC), "superdump.log"));
+				context.Printer = new FilePrinter(logfile.FullName);
 
 				try {
 					if (File.Exists(absoluteDumpFile)) {

--- a/src/SuperDump/SuperDump.csproj
+++ b/src/SuperDump/SuperDump.csproj
@@ -193,7 +193,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SuperDumpmodels\SuperDumpModels.csproj">
+    <ProjectReference Include="..\SuperDumpModels\SuperDumpModels.csproj">
       <Project>{bb6ec51d-3acc-4ade-b09c-4217b4ad3c58}</Project>
       <Name>SuperDumpModels</Name>
     </ProjectReference>

--- a/src/SuperDumpSelector/Program.cs
+++ b/src/SuperDumpSelector/Program.cs
@@ -9,18 +9,25 @@ using System.Reflection;
 namespace SuperDumpSelector {
 	public static class Program {
 		public static void Main(string[] args) {
-			string file;
+			string dumpfile;
 			if (args.Length > 0) {
-				file = args[0];
+				dumpfile = args[0];
 			} else {
 				Console.Write("Enter dump file path: ");
-				file = Console.ReadLine();
+				dumpfile = Console.ReadLine();
+			}
+			string outputfile;
+			if (args.Length > 1) {
+				outputfile = args[1];
+			} else {
+				Console.Write("Enter output file path: ");
+				outputfile = Console.ReadLine();
 			}
 
 			Console.WriteLine(Environment.CurrentDirectory);
-			if (File.Exists(file)) {
+			if (File.Exists(dumpfile)) {
 				var p = new Process();
-				using (DataTarget target = DataTarget.LoadCrashDump(file)) {
+				using (DataTarget target = DataTarget.LoadCrashDump(dumpfile)) {
 					if (target.PointerSize == 8) {
 						p.StartInfo.FileName = ResolvePath(ConfigurationManager.AppSettings["superdumpx64"]);
 						if (!File.Exists(p.StartInfo.FileName)) p.StartInfo.FileName = ResolvePath(ConfigurationManager.AppSettings["superdumpx64_deployment"]);
@@ -33,7 +40,7 @@ namespace SuperDumpSelector {
 						Console.WriteLine("target dump architecture is different than x64 or x86, this is not yet supported!");
 					}
 				}
-				p.StartInfo.Arguments = file;
+				p.StartInfo.Arguments = $"{dumpfile} {outputfile}";
 				p.StartInfo.UseShellExecute = false;
 				p.StartInfo.RedirectStandardOutput = true;
 				p.StartInfo.WorkingDirectory = Path.GetDirectoryName(p.StartInfo.FileName);
@@ -57,7 +64,7 @@ namespace SuperDumpSelector {
 					throw;
 				}
 			} else {
-				throw new FileNotFoundException($"Dump file was not found at {file}. Please try again");
+				throw new FileNotFoundException($"Dump file was not found at {dumpfile}. Please try again");
 			}
 		}
 

--- a/src/SuperDumpService/Controllers/HomeController.cs
+++ b/src/SuperDumpService/Controllers/HomeController.cs
@@ -125,7 +125,7 @@ namespace SuperDumpService.Controllers {
 
 			SDResult res = superDumpRepo.GetResult(bundleId, dumpId);
 
-			return View(new ReportViewModel(bundleId, dumpId) {
+			return base.View(new ReportViewModel(bundleId, dumpId) {
 				BundleFileName = bundleInfo.BundleFileName,
 				DumpFileName = dumpInfo.DumpFileName,
 				Result = res,
@@ -135,8 +135,17 @@ namespace SuperDumpService.Controllers {
 				Files = dumpRepo.GetFileNames(bundleId, dumpId),
 				AnalysisError = dumpInfo.ErrorMessage,
 				ThreadTags = res != null ? res.GetThreadTags() : new HashSet<SDTag>(),
-				PointerSize = res == null ? 8 : (res.SystemContext.ProcessArchitecture == "X86" ? 8 : 12)
+				PointerSize = res == null ? 8 : (res.SystemContext.ProcessArchitecture == "X86" ? 8 : 12),
+				CustomTextResult = ReadCustomTextResult(dumpInfo)
 			});
+		}
+
+		private string ReadCustomTextResult(DumpMetainfo dumpInfo) {
+			SDFileEntry customResultFile = dumpInfo.Files.SingleOrDefault(x => x.Type == SDFileType.CustomTextResult);
+			if (customResultFile == null) return null;
+			FileInfo file = dumpStorage.GetFile(dumpInfo.BundleId, dumpInfo.DumpId, customResultFile.FileName);
+			if (!file.Exists) return null;
+			return System.IO.File.ReadAllText(file.FullName);
 		}
 
 		public IActionResult UploadError() {

--- a/src/SuperDumpService/Controllers/HomeController.cs
+++ b/src/SuperDumpService/Controllers/HomeController.cs
@@ -76,7 +76,7 @@ namespace SuperDumpService.Controllers {
 			if (bundleRepo.ContainsBundle(bundleId)) {
 				return View(new BundleViewModel(bundleRepo.Get(bundleId), dumpRepo.Get(bundleId)));
 			}
-			throw new NotImplementedException("TODO better exception message");
+			throw new NotImplementedException($"bundleid '{bundleId}' does not exist in repository");
 		}
 
 		[HttpPost]

--- a/src/SuperDumpService/Controllers/HomeController.cs
+++ b/src/SuperDumpService/Controllers/HomeController.cs
@@ -84,20 +84,13 @@ namespace SuperDumpService.Controllers {
 			if (ModelState.IsValid) {
 				pathHelper.PrepareDirectories();
 				if (file.Length > 0) {
-					int i = 0;
-					string filePath = Path.Combine(pathHelper.GetUploadsDir(), file.FileName);
-					while (System.IO.File.Exists(filePath)) {
-						filePath = Path.Combine(pathHelper.GetUploadsDir(),
-							Path.GetFileNameWithoutExtension(file.FileName)
-								+ "_" + i
-								+ Path.GetExtension(filePath));
-
-						i++;
-					}
-					using (var fileStream = new FileStream(filePath, FileMode.Create)) {
+					var tempDir = new DirectoryInfo(pathHelper.GetTempDir());
+					tempDir.Create();
+					var filePath = new FileInfo(Path.Combine(tempDir.FullName, file.FileName));
+					using (var fileStream = new FileStream(filePath.FullName, FileMode.Create)) {
 						await file.CopyToAsync(fileStream);
 					}
-					var bundle = new DumpAnalysisInput { Url = filePath, JiraIssue = jiraIssue, FriendlyName = friendlyName };
+					var bundle = new DumpAnalysisInput { Url = filePath.FullName, JiraIssue = jiraIssue, FriendlyName = friendlyName };
 					return Create(bundle);
 				}
 				return View("UploadError", new Error("No filename was provided.", ""));

--- a/src/SuperDumpService/Helpers/PathHelper.cs
+++ b/src/SuperDumpService/Helpers/PathHelper.cs
@@ -61,17 +61,14 @@ namespace SuperDumpService.Helpers {
 			Directory.CreateDirectory(GetHangfireDBDir());
 		}
 
-		public string GetDumpfilePath(string bundleId, string dumpId) {
-			return Path.Combine(GetDumpDirectory(bundleId, dumpId), dumpId + ".dmp");
-		}
-
 		public string GetJsonPath(string bundleId, string dumpId) {
-			return Path.Combine(GetDumpDirectory(bundleId, dumpId), dumpId + ".json");
+			return Path.Combine(GetDumpDirectory(bundleId, dumpId), "superdump-result.json");
 		}
 
 		public string GetDumpSelectorExePath() {
 			return superDumpSelectorExePath;
 		}
+
 		private string GetDumpSelectorExePathFallback() {
 			string dumpselector = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"..\SuperDumpSelector\bin\SuperDumpSelector.exe"));
 			if (!File.Exists(dumpselector)) {

--- a/src/SuperDumpService/Helpers/PathHelper.cs
+++ b/src/SuperDumpService/Helpers/PathHelper.cs
@@ -36,6 +36,10 @@ namespace SuperDumpService.Helpers {
 			return Path.GetFullPath(uploadsDir);
 		}
 
+		public string GetTempDir() {
+			return Path.Combine(GetUploadsDir(), RandomIdGenerator.GetRandomId(3, 16));
+		}
+
 		public string GetWorkingDir() {
 			return Path.GetFullPath(workingDir);
 		}

--- a/src/SuperDumpService/Helpers/ProcessRunner.cs
+++ b/src/SuperDumpService/Helpers/ProcessRunner.cs
@@ -1,0 +1,53 @@
+﻿
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace SuperDumpService.Helpers {
+	public class ProcessRunner : IDisposable {
+		private readonly Process process;
+
+		public string StdOut { get; private set; }
+		public string StdErr { get; private set; }
+		public int ExitCode { get; private set; }
+
+		public ProcessRunner(string executable, string arguments) {
+			this.process = new Process();
+			this.process.StartInfo.FileName = executable;
+			this.process.StartInfo.Arguments = arguments;
+			this.process.StartInfo.RedirectStandardOutput = true;
+			this.process.StartInfo.RedirectStandardError = true;
+			this.process.StartInfo.UseShellExecute = false;
+			this.process.StartInfo.CreateNoWindow = true;
+		}
+
+		public async Task<ProcessRunner> Start() {
+			await Task.Run(() => {
+				process.Start();
+				TrySetPriorityClass(process, ProcessPriorityClass.BelowNormal);
+				StdOut = process.StandardOutput.ReadToEnd(); // important to do ReadToEnd before WaitForExit to avoid deadlock
+				StdErr = process.StandardError.ReadToEnd();
+				process.WaitForExit();
+				ExitCode = process.ExitCode;
+			});
+			return this;
+		}
+
+		private static void TrySetPriorityClass(Process process, ProcessPriorityClass priority) {
+			try {
+				process.PriorityClass = priority;
+			} catch (Exception) {
+				// this might be disallowed, e.g. in Azure WebApps
+			}
+		}
+
+		public async static Task<ProcessRunner> Run(string executable, string arguments) {
+			return await new ProcessRunner(executable, arguments).Start();
+		}
+
+		public void Dispose() {
+			this.process.Dispose();
+		}
+	}
+}

--- a/src/SuperDumpService/Helpers/ProcessRunner.cs
+++ b/src/SuperDumpService/Helpers/ProcessRunner.cs
@@ -16,7 +16,7 @@ namespace SuperDumpService.Helpers {
 		public ProcessRunner(string executable, DirectoryInfo workingDir, params string[] arguments) {
 			this.process = new Process();
 			this.process.StartInfo.FileName = executable;
-			this.process.StartInfo.WorkingDirectory = executable;
+			this.process.StartInfo.WorkingDirectory = workingDir.FullName;
 			this.process.StartInfo.Arguments = string.Join(" ", arguments);
 			this.process.StartInfo.RedirectStandardOutput = true;
 			this.process.StartInfo.RedirectStandardError = true;

--- a/src/SuperDumpService/Helpers/ProcessRunner.cs
+++ b/src/SuperDumpService/Helpers/ProcessRunner.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace SuperDumpService.Helpers {
@@ -12,10 +13,11 @@ namespace SuperDumpService.Helpers {
 		public string StdErr { get; private set; }
 		public int ExitCode { get; private set; }
 
-		public ProcessRunner(string executable, string arguments) {
+		public ProcessRunner(string executable, DirectoryInfo workingDir, params string[] arguments) {
 			this.process = new Process();
 			this.process.StartInfo.FileName = executable;
-			this.process.StartInfo.Arguments = arguments;
+			this.process.StartInfo.WorkingDirectory = executable;
+			this.process.StartInfo.Arguments = string.Join(" ", arguments);
 			this.process.StartInfo.RedirectStandardOutput = true;
 			this.process.StartInfo.RedirectStandardError = true;
 			this.process.StartInfo.UseShellExecute = false;
@@ -42,8 +44,8 @@ namespace SuperDumpService.Helpers {
 			}
 		}
 
-		public async static Task<ProcessRunner> Run(string executable, string arguments) {
-			return await new ProcessRunner(executable, arguments).Start();
+		public async static Task<ProcessRunner> Run(string executable, DirectoryInfo workingDir, params string[] arguments) {
+			return await new ProcessRunner(executable, workingDir, arguments).Start();
 		}
 
 		public void Dispose() {

--- a/src/SuperDumpService/Helpers/Utility.cs
+++ b/src/SuperDumpService/Helpers/Utility.cs
@@ -144,5 +144,26 @@ namespace SuperDumpService.Helpers {
 			}
 			return destFile;
 		}
+
+		public static bool IsSubdirectoryOf(DirectoryInfo parentDir, DirectoryInfo subDir) {
+			var di1 = parentDir;
+			var di2 = subDir;
+			while (di2.Parent != null) {
+				if (DirectoryEquals(di2, di1)) return true;
+				di2 = di2.Parent;
+			}
+			return false;
+		}
+
+		private static bool DirectoryEquals(DirectoryInfo path1, DirectoryInfo path2) {
+			return DirectoryEquals(path1.FullName, path2.FullName);
+		}
+
+		private static bool DirectoryEquals(string path1, string path2) {
+			return string.Equals(
+					Path.GetFullPath(path1).TrimEnd('\\'),
+					Path.GetFullPath(path2).TrimEnd('\\'),
+					StringComparison.OrdinalIgnoreCase);
+		}
 	}
 }

--- a/src/SuperDumpService/Helpers/Utility.cs
+++ b/src/SuperDumpService/Helpers/Utility.cs
@@ -8,6 +8,8 @@ using SuperDumpService.Models;
 using Hangfire;
 using System.IO.Compression;
 using SuperDumpService.Services;
+using System.Reflection;
+using System.ComponentModel;
 
 namespace SuperDumpService.Helpers {
 	public static class Utility {
@@ -83,7 +85,7 @@ namespace SuperDumpService.Helpers {
 		/// </summary>
 		internal static IDictionary<string, string> Sanitize(Dictionary<string, string> sourceDict) {
 			var dict = new Dictionary<string, string>();
-			foreach(var entry in sourceDict) {
+			foreach (var entry in sourceDict) {
 				dict[Sanitize(entry.Key)] = Sanitize(entry.Value);
 			}
 			return dict;
@@ -116,6 +118,31 @@ namespace SuperDumpService.Helpers {
 			return string.Format("{0:n" + decimalPlaces + "}{1}",
 				adjustedSize,
 				SizeSuffixes[mag]);
+		}
+
+		public static string GetEnumDescription(Enum value) {
+			FieldInfo fi = value.GetType().GetField(value.ToString());
+
+			DescriptionAttribute[] attributes =
+				(DescriptionAttribute[])fi.GetCustomAttributes(
+				typeof(DescriptionAttribute),
+				false);
+
+			if (attributes != null &&
+				attributes.Length > 0) {
+				return attributes[0].Description;
+			} else {
+				return value.ToString();
+			}
+		}
+
+		public static async Task<FileInfo> CopyFile(FileInfo sourceFile, FileInfo destFile) {
+			using (Stream source = sourceFile.OpenRead()) {
+				using (Stream destination = destFile.Create()) {
+					await source.CopyToAsync(destination);
+				}
+			}
+			return destFile;
 		}
 	}
 }

--- a/src/SuperDumpService/Models/DumpMetainfo.cs
+++ b/src/SuperDumpService/Models/DumpMetainfo.cs
@@ -43,6 +43,8 @@ namespace SuperDumpService.Models {
 		WinDbg,
 		[Description("Results")]
 		SuperDumpData,
+		[Description("Results")]
+		CustomTextResult,
 
 		[Description("Logs")]
 		SuperDumpLogfile,

--- a/src/SuperDumpService/Models/DumpMetainfo.cs
+++ b/src/SuperDumpService/Models/DumpMetainfo.cs
@@ -40,6 +40,7 @@ namespace SuperDumpService.Models {
 		SuperDumpData,
 		SuperDumpLogfile,
 		LinuxLibraries,
-		Other
+		Other,
+		SiblingFile
 	}
 }

--- a/src/SuperDumpService/Models/DumpMetainfo.cs
+++ b/src/SuperDumpService/Models/DumpMetainfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -35,12 +36,22 @@ namespace SuperDumpService.Models {
 	}
 
 	public enum SDFileType {
+		[Description("Primary Dump")]
 		PrimaryDump,
+
+		[Description("Results")]
 		WinDbg,
+		[Description("Results")]
 		SuperDumpData,
+
+		[Description("Logs")]
 		SuperDumpLogfile,
+
+		[Description("Other files")]
 		LinuxLibraries,
+		[Description("Other files")]
+		SiblingFile,
+		[Description("Other files")]
 		Other,
-		SiblingFile
 	}
 }

--- a/src/SuperDumpService/Models/DumpMetainfo.cs
+++ b/src/SuperDumpService/Models/DumpMetainfo.cs
@@ -8,6 +8,7 @@ namespace SuperDumpService.Models {
 		public string BundleId { get; set; }
 		public string DumpId { get; set; }
 		public string DumpFileName { get; set; } // original filename. just informational.
+		public DumpType DumpType { get; set; } = DumpType.WindowsDump; // default to windows, for compatibility to existing repos (which will only contain windows dumps)
 		public DateTime Created { get; set; }
 		public DateTime Finished { get; set; }
 		public DumpStatus Status { get; set; }
@@ -25,11 +26,20 @@ namespace SuperDumpService.Models {
 		public DateTime ExpirationDate { get; set; }
 	}
 
+	public enum DumpType {
+		// *.dmp        -> windows user-space minidump or user-space fulldump
+		WindowsDump,
+		
+		// *.core.gz    -> linux coredump file
+		LinuxCoreDump
+	}
+
 	public enum SDFileType {
 		PrimaryDump,
 		WinDbg,
 		SuperDumpData,
 		SuperDumpLogfile,
+		LinuxLibraries,
 		Other
 	}
 }

--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -46,7 +46,7 @@ namespace SuperDumpService.Services {
 					throw new Exception("unknown dumptype. here be dragons");
 				}
 				dumpRepo.SetDumpStatus(dumpInfo.BundleId, dumpInfo.DumpId, DumpStatus.Finished);
-			} catch (OperationCanceledException e) {
+			} catch (Exception e) {
 				Console.WriteLine(e.Message);
 				dumpRepo.SetDumpStatus(dumpInfo.BundleId, dumpInfo.DumpId, DumpStatus.Failed, e.ToString());
 			} finally {
@@ -75,7 +75,8 @@ namespace SuperDumpService.Services {
 
 		private async Task AnalyzeLinux(DumpMetainfo dumpInfo, DirectoryInfo workingDir, string dumpFilePath) {
 			using (var process = await ProcessRunner.Run("ipconfig", workingDir, "")) {
-				Console.WriteLine(process.StdOut);
+				File.WriteAllText(Path.Combine(workingDir.FullName, "linux-analysis.txt"), process.StdOut);
+				dumpRepo.AddFile(dumpInfo.BundleId, dumpInfo.DumpId, "linux-analysis.txt", SDFileType.CustomTextResult);
 			}
 		}
 	}

--- a/src/SuperDumpService/Services/DumpRepository.cs
+++ b/src/SuperDumpService/Services/DumpRepository.cs
@@ -55,7 +55,7 @@ namespace SuperDumpService.Services {
 		/// Does NOT start analysis
 		/// </summary>
 		/// <returns></returns>
-		public async Task<DumpMetainfo> AddDump(string bundleId, FileInfo sourcePath) {
+		public async Task<DumpMetainfo> CreateDump(string bundleId, FileInfo sourcePath) {
 			DumpMetainfo dumpInfo;
 			string dumpId;
 			lock (sync) {
@@ -73,7 +73,7 @@ namespace SuperDumpService.Services {
 			}
 			storage.Create(bundleId, dumpId);
 			
-			FileInfo destFile = await storage.AddDumpFile(bundleId, dumpId, sourcePath);
+			FileInfo destFile = await storage.AddFileCopy(bundleId, dumpId, sourcePath);
 			AddSDFile(bundleId, dumpId, destFile.Name, SDFileType.PrimaryDump);
 			return dumpInfo;
 		}
@@ -126,6 +126,11 @@ namespace SuperDumpService.Services {
 				dumpInfo.Finished = DateTime.Now;
 			}
 			storage.Store(dumpInfo);
+		}
+
+		internal async Task AddSiblingFile(string bundleId, string dumpId, FileInfo siblingFile) {
+			await storage.AddFileCopy(bundleId, dumpId, siblingFile);
+			AddSDFile(bundleId, dumpId, siblingFile.Name, SDFileType.SiblingFile);
 		}
 	}
 }

--- a/src/SuperDumpService/Services/DumpRepository.cs
+++ b/src/SuperDumpService/Services/DumpRepository.cs
@@ -128,9 +128,13 @@ namespace SuperDumpService.Services {
 			storage.Store(dumpInfo);
 		}
 
-		internal async Task AddSiblingFile(string bundleId, string dumpId, FileInfo siblingFile) {
-			await storage.AddFileCopy(bundleId, dumpId, siblingFile);
-			AddSDFile(bundleId, dumpId, siblingFile.Name, SDFileType.SiblingFile);
+		internal async Task AddFileCopy(string bundleId, string dumpId, FileInfo file, SDFileType type) {
+			await storage.AddFileCopy(bundleId, dumpId, file);
+			AddSDFile(bundleId, dumpId, file.Name, type);
+		}
+
+		internal void AddFile(string bundleId, string dumpId, string filename, SDFileType type) {
+			AddSDFile(bundleId, dumpId, filename, type);
 		}
 	}
 }

--- a/src/SuperDumpService/Services/DumpRepository.cs
+++ b/src/SuperDumpService/Services/DumpRepository.cs
@@ -65,6 +65,7 @@ namespace SuperDumpService.Services {
 					BundleId = bundleId,
 					DumpId = dumpId,
 					DumpFileName = Utility.MakeRelativePath(pathHelper.GetUploadsDir(), sourcePath),
+					DumpType = DetermineDumpType(sourcePath),
 					Created = DateTime.Now,
 					Status = DumpStatus.Created
 				};
@@ -75,6 +76,16 @@ namespace SuperDumpService.Services {
 			FileInfo destFile = await storage.AddDumpFile(bundleId, dumpId, sourcePath);
 			AddSDFile(bundleId, dumpId, destFile.Name, SDFileType.PrimaryDump);
 			return dumpInfo;
+		}
+
+		internal string GetDumpFilePath(string bundleId, string dumpId) {
+			return storage.GetDumpFilePath(bundleId, dumpId);
+		}
+
+		private DumpType DetermineDumpType(FileInfo sourcePath) {
+			if (sourcePath.Name.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase)) return DumpType.WindowsDump;
+			if (sourcePath.Name.EndsWith(".core.gz", StringComparison.OrdinalIgnoreCase)) return DumpType.LinuxCoreDump;
+			throw new InvalidDataException($"cannot determine dumptype of {sourcePath.FullName}");
 		}
 
 		private void AddSDFile(string bundleId, string dumpId, string filename, SDFileType type) {

--- a/src/SuperDumpService/Services/DumpStorageFilebased.cs
+++ b/src/SuperDumpService/Services/DumpStorageFilebased.cs
@@ -85,13 +85,7 @@ namespace SuperDumpService.Services {
 		/// actually copies a file into the dumpdirectory
 		/// </summary>
 		internal async Task<FileInfo> AddFileCopy(string bundleId, string dumpId, FileInfo sourcePath) {
-			var destFile = new FileInfo(Path.Combine(pathHelper.GetDumpDirectory(bundleId, dumpId), sourcePath.Name));
-			using (Stream source = sourcePath.OpenRead()) {
-				using (Stream destination = destFile.Create()) {
-					await source.CopyToAsync(destination);
-				}
-			}
-			return destFile;
+			return await Utility.CopyFile(sourcePath, new FileInfo(Path.Combine(pathHelper.GetDumpDirectory(bundleId, dumpId), sourcePath.Name)));
 		}
 
 		internal void DeleteDumpFile(string bundleId, string dumpId) {

--- a/src/SuperDumpService/Services/DumpStorageFilebased.cs
+++ b/src/SuperDumpService/Services/DumpStorageFilebased.cs
@@ -84,7 +84,7 @@ namespace SuperDumpService.Services {
 		/// <summary>
 		/// actually copies a file into the dumpdirectory
 		/// </summary>
-		internal async Task<FileInfo> AddDumpFile(string bundleId, string dumpId, FileInfo sourcePath) {
+		internal async Task<FileInfo> AddFileCopy(string bundleId, string dumpId, FileInfo sourcePath) {
 			var destFile = new FileInfo(Path.Combine(pathHelper.GetDumpDirectory(bundleId, dumpId), sourcePath.Name));
 			using (Stream source = sourcePath.OpenRead()) {
 				using (Stream destination = destFile.Create()) {
@@ -125,7 +125,7 @@ namespace SuperDumpService.Services {
 				};
 			}
 		}
-
+		
 		private SDFileEntry GetSDFileEntry(DumpMetainfo dumpInfo, FileInfo fileInfo) {
 			// the file should be registered in dumpInfo
 			SDFileEntry fileEntry = dumpInfo.Files.Where(x => x.FileName == fileInfo.Name).SingleOrDefault();

--- a/src/SuperDumpService/Services/SuperDumpRepository.cs
+++ b/src/SuperDumpService/Services/SuperDumpRepository.cs
@@ -133,7 +133,7 @@ namespace SuperDumpService.Services {
 				var dir = file.Directory;
 				foreach(var siblingFile in dir.EnumerateFiles()) {
 					if (siblingFile.FullName == file.FullName) continue; // don't add actual dump file twice
-					await dumpRepo.AddSiblingFile(bundleId, dumpInfo.DumpId, siblingFile);
+					await dumpRepo.AddFileCopy(bundleId, dumpInfo.DumpId, siblingFile, SDFileType.SiblingFile);
 				}
 			}
 

--- a/src/SuperDumpService/Services/SuperDumpRepository.cs
+++ b/src/SuperDumpService/Services/SuperDumpRepository.cs
@@ -164,11 +164,11 @@ namespace SuperDumpService.Services {
 		public async Task DownloadAndScheduleProcessFile(string bundleId, string url, string filename) {
 			bundleRepo.SetBundleStatus(bundleId, BundleStatus.Downloading);
 			try {
-				using (var tempFile = await downloadService.Download(bundleId, url, filename)) {
+				using (TempDirectoryHandle tempDir = await downloadService.Download(bundleId, url, filename)) {
 					// this class should only do downloading. 
 					// unf. i could not find a good way to *not* make this call from with DownloadService
 					// hangfire supports continuations, but not parameterized. i found no way to pass the result (TempFileHandle) over to the continuation
-					await ProcessFile(bundleId, tempFile.File);
+					await ProcessDir(bundleId, tempDir.Dir);
 				}
 				bundleRepo.SetBundleStatus(bundleId, BundleStatus.Finished);
 			} catch (Exception e) {

--- a/src/SuperDumpService/SuperDumpService.csproj
+++ b/src/SuperDumpService/SuperDumpService.csproj
@@ -47,6 +47,6 @@
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.2.301" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SuperDumpmodels\SuperDumpModels.csproj" />
+    <ProjectReference Include="..\SuperDumpModels\SuperDumpModels.csproj" />
   </ItemGroup>
 </Project>

--- a/src/SuperDumpService/SuperDumpService.csproj
+++ b/src/SuperDumpService/SuperDumpService.csproj
@@ -47,6 +47,6 @@
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.2.301" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SuperDumpModels\SuperDumpModels.csproj" />
+    <ProjectReference Include="..\SuperDumpmodels\SuperDumpModels.csproj" />
   </ItemGroup>
 </Project>

--- a/src/SuperDumpService/SuperDumpSettings.cs
+++ b/src/SuperDumpService/SuperDumpSettings.cs
@@ -12,5 +12,6 @@
 		public bool DeleteDumpAfterAnalysis { get; set; }
 		public bool DumpDownloadable { get; set; } = true;
 		public int MaxUploadSizeMB { get; set; } = 16000;
+		public bool IncludeOtherFilesInReport { get; set; }
 	}
 }

--- a/src/SuperDumpService/SuperDumpSettings.cs
+++ b/src/SuperDumpService/SuperDumpSettings.cs
@@ -13,5 +13,6 @@
 		public bool DumpDownloadable { get; set; } = true;
 		public int MaxUploadSizeMB { get; set; } = 16000;
 		public bool IncludeOtherFilesInReport { get; set; }
+		public string LinuxCommandTemplate { get; set; }
 	}
 }

--- a/src/SuperDumpService/ViewModels/FileViewModel.cs
+++ b/src/SuperDumpService/ViewModels/FileViewModel.cs
@@ -1,0 +1,15 @@
+﻿using SuperDumpService.Models;
+
+namespace SuperDumpService.ViewModels {
+	public class FileViewModel {
+		public string BundleId { get; private set; }
+		public string DumpId { get; private set; }
+		public SDFileInfo File { get; private set; }
+
+		public FileViewModel(string bundleId, string dumpId, SDFileInfo file) {
+			this.BundleId = bundleId;
+			this.DumpId = dumpId;
+			this.File = file;
+		}
+	}
+}

--- a/src/SuperDumpService/ViewModels/ReportViewModel.cs
+++ b/src/SuperDumpService/ViewModels/ReportViewModel.cs
@@ -18,6 +18,7 @@ namespace SuperDumpService.ViewModels {
 		public ISet<SDTag> ThreadTags { get; set; }
 		public int PointerSize { get; set; }
 		public IDictionary<string, string> CustomProperties { get; set; } = new Dictionary<string, string>();
+		public string CustomTextResult { get; set; }
 
 		public ReportViewModel(string bundleId, string dumpId) {
 			this.BundleId = bundleId;

--- a/src/SuperDumpService/Views/Home/Report.cshtml
+++ b/src/SuperDumpService/Views/Home/Report.cshtml
@@ -75,12 +75,18 @@
 			<h2>Analysis failed with errors, no report avaliable.</h2>
 			<pre>Error: @Model.AnalysisError</pre>
 		} else if (Model.Result == null) {
-			<h2>hang tight, still processing</h2>
-			<script>
-				setTimeout(function () {
-					window.location.reload(1);
-				}, 5000);
-			</script>
+			if (Model.CustomTextResult != null) {
+				<section>
+					<pre>@Model.CustomTextResult</pre>
+				</section>
+			} else {
+				<h2>hang tight, still processing</h2>
+				<script>
+					setTimeout(function () {
+						window.location.reload(1);
+					}, 5000);
+				</script>
+			}
 		} else {
 			<section>
 				@{Html.RenderPartial("_Summary");}
@@ -102,4 +108,4 @@
 			</section>
 					}
 	</div>
-					}
+}

--- a/src/SuperDumpService/Views/Home/Report.cshtml
+++ b/src/SuperDumpService/Views/Home/Report.cshtml
@@ -1,6 +1,7 @@
 ﻿@model SuperDumpService.ViewModels.ReportViewModel
 @using SuperDumpService.Helpers
 @using SuperDumpService.Models
+@using SuperDumpService.ViewModels
 
 @{
 	ViewData["Title"] = "Report";
@@ -50,34 +51,22 @@
 
 		<dt>Files:</dt>
 		<dd>
-			<ul class="flat">
-				@foreach (SDFileInfo file in Model.Files.OrderBy(x => x.FileEntry.Type)) {
-					<li>
-						@if (file.Downloadable) {
-							<a asp-controller="Home" asp-action="DownloadFile" asp-route-bundleId="@Model.BundleId" asp-route-dumpId="@Model.DumpId" asp-route-filename="@file.FileInfo.Name">
-								@if (file.FileEntry != null) {
-									if (file.FileEntry.Type == SDFileType.PrimaryDump) {
-										<img src="~/images/bomb.png" />
-									} else if (file.FileEntry.Type == SDFileType.WinDbg) {
-										<img src="~/images/windbg.png" />
-									}
-								}
-								@file.FileInfo.Name
-							</a> <span class="filesize">(@SuperDumpService.Helpers.Utility.FormattedBytes(file.SizeInBytes, 0))</span>
-						} else {
-							@if (file.FileEntry != null) {
-								if (file.FileEntry.Type == SDFileType.PrimaryDump) {
-									<img src="~/images/bomb.png" />
-								} else if (file.FileEntry.Type == SDFileType.WinDbg) {
-									<img src="~/images/windbg.png" />
-								}
+			<dl class="dl-horizontal">
+				@{ var sequence = new List<string> { "Primary Dump", "Other files", "Logs", "Results" }; }
+					@foreach (var filetype in Model.Files.Select(x => Utility.GetEnumDescription(x.FileEntry.Type)).Distinct()
+						.OrderBy(x => sequence.IndexOf(x) < 0 ? int.MaxValue : sequence.IndexOf(x))) { // somewhat ugly hack to control the order of file categories
+					<dt class="filesize">@filetype.ToString()</dt>
+					<dd class="">
+						<ul class="flat">
+							@foreach (SDFileInfo file in Model.Files.Where(x => Utility.GetEnumDescription(x.FileEntry.Type) == filetype).OrderBy(x => x.FileEntry.FileName)) {
+								<li>
+									@{Html.RenderPartial("_File", new FileViewModel(Model.BundleId, Model.DumpId, file));}
+								</li>
 							}
-							@file.FileInfo.Name
-							<span class="filesize">(@SuperDumpService.Helpers.Utility.FormattedBytes(file.SizeInBytes, 0))</span>
-						}
-					</li>
+						</ul>
+					</dd>
 				}
-			</ul>
+				</dl>
 		</dd>
 	</dl>
 

--- a/src/SuperDumpService/Views/Home/_File.cshtml
+++ b/src/SuperDumpService/Views/Home/_File.cshtml
@@ -1,0 +1,10 @@
+﻿@model SuperDumpService.ViewModels.FileViewModel
+@using SuperDumpService.Models;
+
+@if (Model.File.Downloadable) {
+	<a asp-controller="Home" asp-action="DownloadFile" asp-route-bundleId="@Model.BundleId" asp-route-dumpId="@Model.DumpId" asp-route-filename="@Model.File.FileInfo.Name">
+		@Model.File.FileInfo.Name</a> <span class="filesize">(@SuperDumpService.Helpers.Utility.FormattedBytes(Model.File.SizeInBytes, 0))</span>
+} else {
+	@Model.File.FileInfo.Name
+	<span class="filesize">(@SuperDumpService.Helpers.Utility.FormattedBytes(Model.File.SizeInBytes, 0))</span>
+}

--- a/src/SuperDumpService/wwwroot/css/site.css
+++ b/src/SuperDumpService/wwwroot/css/site.css
@@ -430,7 +430,7 @@ a.copyButtonForJira:hover {
 .dl-horizontal {
 	font-family: Courier New, Courier, monospace;
 	font-size: 12px;
-	padding-top: 6px;
+	padding-top: 16px;
 	padding-bottom: 6px;
 	margin: 0px;
 }
@@ -442,10 +442,10 @@ a.copyButtonForJira:hover {
 }
 
 .smaller dt {
-	width: 70px;
+	width: 100px;
 }
 .smaller dd {
-	margin-left: 80px;
+	margin-left: 110px;
 }
 
 /* make open/close threads faster*/

--- a/src/SuperDumpTests/SuperDumpTests.csproj
+++ b/src/SuperDumpTests/SuperDumpTests.csproj
@@ -116,7 +116,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SuperDumpmodels\SuperDumpModels.csproj">
+    <ProjectReference Include="..\SuperDumpModels\SuperDumpModels.csproj">
       <Project>{bb6ec51d-3acc-4ade-b09c-4217b4ad3c58}</Project>
       <Name>SuperDumpModels</Name>
     </ProjectReference>


### PR DESCRIPTION
Big preparation step for linux coredump support:
 * `.core.gz` now trigger an analysis just like windows `.dmp` files.
 * when uploading a `zip` file, the files that are located in the same directory as a dump, are now added to the report (if setting *"IncludeOtherFilesInReport"* is true). The reason is:
 ** Our automated linux crashdumps, contain an additional library next to the core.gz file, which is called libs.tar.gz and contains all the linux libs, that are necessary for solid analysis.
 ** Also our automated windows crashdumps contain some additional files, which are usually interesting. Adding them to SuperDump just makes it more convenient.
 * renamed some output-files: 
 ** dumps now keep their original name
 ** results are not named after the DumpId anymore, but have speaking names
 * report now shows file-list a bit better (with categories). hopefully becomes clearer.
 * added support for "custom text results". maybe this is handy if we can't get our GDB/linux scripts to write proper json files. Some text-output will still be better than nothing.