### PR TITLE
fix error with multiple files in metainfo

### DIFF
--- a/src/SuperDumpService/Services/DumpStorageFilebased.cs
+++ b/src/SuperDumpService/Services/DumpStorageFilebased.cs
@@ -126,7 +126,7 @@ namespace SuperDumpService.Services {
 		
 		private SDFileEntry GetSDFileEntry(DumpMetainfo dumpInfo, FileInfo fileInfo) {
 			// the file should be registered in dumpInfo
-			SDFileEntry fileEntry = dumpInfo.Files.Where(x => x.FileName == fileInfo.Name).SingleOrDefault();
+			SDFileEntry fileEntry = dumpInfo.Files.Where(x => x.FileName == fileInfo.Name).FirstOrDefault(); // due to a bug, multiple entries for the same file could exist
 			if (fileEntry != null) return fileEntry;
 
 			// but if it's not registered, do some heuristic to figure out which type of file it is.


### PR DESCRIPTION
due to a glitch with re-running analysis, file-entries might be added multiple times. shouldn't happen too often, so made the easy fix to just accept that (and take the first file)