### PR TITLE
extended command templates.

### DIFF
--- a/conf/appsettings.json
+++ b/conf/appsettings.json
@@ -26,13 +26,21 @@
 		"DumpDownloadable": "true",
 		"MaxUploadSizeMB": "16000",
 		"IncludeOtherFilesInReport": "true", // if true, sibling files to a crashdump within a zip-file are copied to the dump-report directory.
-		"LinuxCommandTemplate": "myanalysis.sh {coredump} {outputjson}",
 		"BinPath": [
 			"../SuperDump.DebugDiag/",
 			"../SuperDump.DebugDiag/bin/"
 		],
-		"Cdbx86": "C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe",
-		"Cdbx64": "C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe"
+
+		// possible template arguments:
+		// {dumppath}: full path to primary dump file
+		// {dumpname}: filename of primary dump file
+		// {dumpdir}: path to directory which contains the primary dump file
+		// {outputpath}: full path to output json file
+		// {outputname}: filename of output json file
+		"WindowsInteractiveCommandx86": "\"C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe\" -z {dumppath}",
+		"WindowsInteractiveCommandx64": "\"C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe\" -z {dumppath}",
+		"LinuxAnalysisCommand": "docker run -it --rm -v {dumpdir}:/dump linux-superdump /root/prepare_crash_artifacts_superdump.sh {dumpname} /dump/{outputname}",
+		"LinuxInteractiveCommand": "docker run -it --rm -v {dumpdir}:/dump linux-superdump /dump/gdb.sh"
 	},
 	"ApplicationInsights": {
 		"InstrumentationKey": "-"

--- a/src/SuperDumpService/Controllers/HomeController.cs
+++ b/src/SuperDumpService/Controllers/HomeController.cs
@@ -145,10 +145,10 @@ namespace SuperDumpService.Controllers {
 		}
 
 		private string ReadCustomTextResult(DumpMetainfo dumpInfo) {
-			SDFileEntry customResultFile = dumpInfo.Files.SingleOrDefault(x => x.Type == SDFileType.CustomTextResult);
+			SDFileEntry customResultFile = dumpInfo.Files.FirstOrDefault(x => x.Type == SDFileType.CustomTextResult);
 			if (customResultFile == null) return null;
 			FileInfo file = dumpStorage.GetFile(dumpInfo.BundleId, dumpInfo.DumpId, customResultFile.FileName);
-			if (!file.Exists) return null;
+			if (file == null || !file.Exists) return null;
 			return System.IO.File.ReadAllText(file.FullName);
 		}
 

--- a/src/SuperDumpService/Helpers/Utility.cs
+++ b/src/SuperDumpService/Helpers/Utility.cs
@@ -10,6 +10,8 @@ using System.IO.Compression;
 using SuperDumpService.Services;
 using System.Reflection;
 using System.ComponentModel;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace SuperDumpService.Helpers {
 	public static class Utility {
@@ -164,6 +166,15 @@ namespace SuperDumpService.Helpers {
 					Path.GetFullPath(path1).TrimEnd('\\'),
 					Path.GetFullPath(path2).TrimEnd('\\'),
 					StringComparison.OrdinalIgnoreCase);
+		}
+
+		public static void ExtractExe(string command, out string executable, out string arguments) {
+			var parts = Regex.Matches(command, @"[\""].+?[\""]|[^ ]+")
+				.Cast<Match>()
+				.Select(m => m.Value)
+				.ToList();
+			executable = parts.First();
+			arguments = string.Join(" ", parts.Skip(1).ToArray());
 		}
 	}
 }

--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -106,18 +106,19 @@ namespace SuperDumpService.Services {
 		}
 
 		private async Task AnalyzeLinux(DumpMetainfo dumpInfo, DirectoryInfo workingDir, string dumpFilePath) {
-			string command = settings.Value.LinuxCommandTemplate;
+			string command = settings.Value.LinuxAnalysisCommand;
 
 			if (string.IsNullOrEmpty(command)) {
 				throw new ArgumentNullException("'LinuxCommandTemplate' setting is not configured.");
 			}
 
-			command = command.Replace("{coredump}", dumpFilePath);
-			command = command.Replace("{outputjson}", pathHelper.GetJsonPath(dumpInfo.BundleId, dumpInfo.DumpId));
+			command = command.Replace("{dumpdir}", workingDir.FullName);
+			command = command.Replace("{dumppath}", dumpFilePath);
+			command = command.Replace("{dumpname}", Path.GetFileName(dumpFilePath));
+			command = command.Replace("{outputpath}", pathHelper.GetJsonPath(dumpInfo.BundleId, dumpInfo.DumpId));
+			command = command.Replace("{outputname}", Path.GetFileName(pathHelper.GetJsonPath(dumpInfo.BundleId, dumpInfo.DumpId)));
 
-			var parts = command.Split(' ');
-			string executable = parts.First();
-			string arguments = string.Join(" ", parts.Skip(1).ToArray());
+			Utility.ExtractExe(command, out string executable, out string arguments);
 
 			Console.WriteLine($"running exe='{executable}', args='{arguments}'");
 			using (var process = await ProcessRunner.Run(executable, workingDir, arguments)) {

--- a/src/SuperDumpService/Services/DumpStorageFilebased.cs
+++ b/src/SuperDumpService/Services/DumpStorageFilebased.cs
@@ -80,7 +80,8 @@ namespace SuperDumpService.Services {
 		}
 
 		public string GetDumpFilePath(string bundleId, string dumpId) {
-			var filename = GetSDFileInfos(bundleId, dumpId).Single(x => x.FileEntry.Type == SDFileType.PrimaryDump).FileInfo;
+			var filename = GetSDFileInfos(bundleId, dumpId).FirstOrDefault(x => x.FileEntry.Type == SDFileType.PrimaryDump).FileInfo;
+			if (filename == null) return null;
 			if (!filename.Exists) return null;
 			return filename.FullName;
 		}

--- a/src/SuperDumpService/SuperDumpSettings.cs
+++ b/src/SuperDumpService/SuperDumpSettings.cs
@@ -15,9 +15,10 @@ namespace SuperDumpService {
 		public bool DumpDownloadable { get; set; } = true;
 		public int MaxUploadSizeMB { get; set; } = 16000;
 		public bool IncludeOtherFilesInReport { get; set; }
-		public string LinuxCommandTemplate { get; set; }
 		public IEnumerable<string> BinPath { get; set; }
-		public string Cdbx86 { get; set; }
-		public string Cdbx64 { get; set; }
+		public string WindowsInteractiveCommandx86 { get; set; }
+		public string WindowsInteractiveCommandx64 { get; set; }
+		public string LinuxAnalysisCommand { get; set; }
+		public string LinuxInteractiveCommand { get; set; }
 	}
 }


### PR DESCRIPTION
Makes it easier to invoke linux coredump analysis scripts, by adding new command template arguments.
```
{dumppath}: full path to primary dump file
{dumpname}: filename of primary dump file
{dumpdir}: path to directory which contains the primary dump file
{outputpath}: full path to output json file
{outputname}: filename of output json file
```

It's possible to use Docker f. Windows and Hyper-V to invoke Linux dump analysis scripts. These scripts are not yet part of this repository though.