### PR TITLE
don't let superdump.exe and superdumpselector.exe crash in case of errors

### DIFF
--- a/build/conf/appsettings.json
+++ b/build/conf/appsettings.json
@@ -26,13 +26,21 @@
 		"DumpDownloadable": "true",
 		"MaxUploadSizeMB": "16000",
 		"IncludeOtherFilesInReport": "true", // if true, sibling files to a crashdump within a zip-file are copied to the dump-report directory.
-		"LinuxCommandTemplate": "myanalysis.sh {coredump} {outputjson}",
 		"BinPath": [
 			"../SuperDump.DebugDiag/",
 			"../SuperDump.DebugDiag/bin/"
 		],
-		"Cdbx86": "C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe",
-		"Cdbx64": "C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe"
+
+		// possible template arguments:
+		// {dumppath}: full path to primary dump file
+		// {dumpname}: filename of primary dump file
+		// {dumpdir}: path to directory which contains the primary dump file
+		// {outputpath}: full path to output json file
+		// {outputname}: filename of output json file
+		"WindowsInteractiveCommandx86": "\"C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe\" -z {dumppath}",
+		"WindowsInteractiveCommandx64": "\"C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe\" -z {dumppath}",
+		"LinuxAnalysisCommand": "docker run -it --rm -v {dumpdir}:/dump linux-superdump /root/prepare_crash_artifacts_superdump.sh {dumpname} /dump/{outputname}",
+		"LinuxInteractiveCommand": "docker run -i --rm -v {dumpdir}:/dump linux-superdump /dump/gdb.sh"
 	},
 	"ApplicationInsights": {
 		"InstrumentationKey": "-"

--- a/src/SuperDump/Program.cs
+++ b/src/SuperDump/Program.cs
@@ -15,7 +15,7 @@ namespace SuperDump {
 		private static DumpContext context;
 		private static DataTarget target;
 
-		private static void Main(string[] args) {
+		private static int Main(string[] args) {
 			using (context = new DumpContext()) {
 				Console.WriteLine("SuperDump - Windows dump analysis tool");
 				Console.WriteLine("--------------------------");
@@ -109,9 +109,10 @@ namespace SuperDump {
 					}
 				} catch (Exception e) {
 					context.WriteError($"Exception happened: {e}");
-					throw;
+					return 1;
 				}
 			}
+			return 0;
 		}
 
 		private static void LoadDump(string absoluteDumpFile) {

--- a/src/SuperDumpSelector/Program.cs
+++ b/src/SuperDumpSelector/Program.cs
@@ -10,7 +10,7 @@ using SuperDump.Common;
 
 namespace SuperDumpSelector {
 	public static class Program {
-		public static void Main(string[] args) {
+		public static int Main(string[] args) {
 			string dumpfile;
 			if (args.Length > 0) {
 				dumpfile = args[0];
@@ -27,12 +27,19 @@ namespace SuperDumpSelector {
 			}
 
 			Console.WriteLine(Environment.CurrentDirectory);
-			if (File.Exists(dumpfile)) {
-				var superDumpPathInfo = FindSuperDumpPath(dumpfile);
-				RunSuperDump(superDumpPathInfo, dumpfile, outputfile).Wait();
-			} else {
-				throw new FileNotFoundException($"Dump file was not found at {dumpfile}. Please try again");
+
+			try {
+				if (File.Exists(dumpfile)) {
+					var superDumpPathInfo = FindSuperDumpPath(dumpfile);
+					RunSuperDump(superDumpPathInfo, dumpfile, outputfile).Wait();
+				} else {
+					throw new FileNotFoundException($"Dump file was not found at {dumpfile}. Please try again");
+				}
+			} catch (Exception e) {
+				Console.Error.WriteLine($"SuperDumpSelector failed: {e}");
+				return 1;
 			}
+			return 0;
 		}
 
 		private static FileInfo FindSuperDumpPath(string dumpfile) {


### PR DESCRIPTION
We actually just need a non-zero exit code in case analysis failed for some reason. No need to let it crash via unhandled exception.