### PR TITLE
improve exception handling in LoadDump

### DIFF
--- a/src/SuperDump/Program.cs
+++ b/src/SuperDump/Program.cs
@@ -135,14 +135,12 @@ namespace SuperDump {
 			} catch (InvalidOperationException ex) {
 				context.WriteError("wrong architecture");
 				context.WriteLine(ex.Message);
-				context.Dispose();
 				throw;
 			} catch (Exception ex) {
-				context.WriteError("Wrong architecture (not started with SuperDumpSelector) or CLR could not be loaded");
+				context.WriteError("An exception occured while loading crash dump.");
 				context.WriteError(ex.Message);
 				context.WriteLine(ex.StackTrace);
-				//context.Dispose();
-				//throw ex;
+				throw;
 			}
 		}
 


### PR DESCRIPTION
because exceptions were swallowed previously, leading to confusing messages. see https://github.com/Dynatrace/superdump/issues/52