### PR TITLE
Linux analysis bugfixes

### DIFF
--- a/src/SuperDump.Analyzer.Linux/Analysis/CoreDumpAnalyzer.cs
+++ b/src/SuperDump.Analyzer.Linux/Analysis/CoreDumpAnalyzer.cs
@@ -35,7 +35,6 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 		public async Task<LinuxAnalyzerExitCode> AnalyzeAsync(string inputFile, string outputFile) {
 			IFileInfo coredump = Prepare(inputFile);
 			if (coredump == null) {
-				// TODO write error into output file
 				return LinuxAnalyzerExitCode.NoCoredumpFound;
 			}
 			Console.WriteLine($"Processing core dump file: {coredump}");

--- a/src/SuperDump.Analyzer.Linux/Analysis/CoreDumpAnalyzer.cs
+++ b/src/SuperDump.Analyzer.Linux/Analysis/CoreDumpAnalyzer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using SuperDump.Analyzer.Linux.Boundary;
 using System.Threading.Tasks;
 using SuperDump.Analyzer.Common;
+using SuperDump.Common;
 
 namespace SuperDump.Analyzer.Linux.Analysis {
 	public class CoreDumpAnalyzer {
@@ -31,19 +32,24 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 			return coredump;
 		}
 
-		public async Task AnalyzeAsync(string inputFile, string outputFile) {
+		public async Task<LinuxAnalyzerExitCode> AnalyzeAsync(string inputFile, string outputFile) {
 			IFileInfo coredump = Prepare(inputFile);
 			if (coredump == null) {
 				// TODO write error into output file
-				return;
+				return LinuxAnalyzerExitCode.NoCoredumpFound;
 			}
 			Console.WriteLine($"Processing core dump file: {coredump}");
 
 			SDResult analysisResult = new SDResult();
-			new UnwindAnalyzer(coredump, analysisResult).Analyze();
-			(analysisResult.SystemContext as SDCDSystemContext).DumpFileName = coredump.FullName;
 			Console.WriteLine("Retrieving shared libraries ...");
 			await new SharedLibAnalyzer(filesystem, coredump, analysisResult).AnalyzeAsync();
+			if((analysisResult?.SystemContext?.Modules?.Count ?? 0) == 0) {
+				Console.WriteLine("Failed to extract shared libraries from core dump. Terminating because further analysis will not make sense.");
+				return LinuxAnalyzerExitCode.FileNoteMissing;
+			} else {
+				Console.WriteLine($"Detected {analysisResult.SystemContext.Modules.Count} shared libraries.");
+			}
+			new UnwindAnalyzer(coredump, analysisResult).Analyze();
 			Console.WriteLine("Finding executable file ...");
 			new ExecutablePathAnalyzer(filesystem, analysisResult.SystemContext as SDCDSystemContext).Analyze();
 			Console.WriteLine("Retrieving agent version if available ...");
@@ -62,6 +68,7 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 			   .Analyze();
 			File.WriteAllText(outputFile, analysisResult.SerializeToJSON());
 			Console.WriteLine("Finished coredump analysis.");
+			return LinuxAnalyzerExitCode.Success;
 		}
 
 		private IFileInfo GetCoreDumpFilePath(string inputFile) {

--- a/src/SuperDump.Analyzer.Linux/Analysis/SharedLibAnalyzer.cs
+++ b/src/SuperDump.Analyzer.Linux/Analysis/SharedLibAnalyzer.cs
@@ -28,8 +28,12 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 		}
 
 		public async Task AnalyzeAsync() {
+			SDCDSystemContext context = (analysisResult.SystemContext as SDCDSystemContext);
+			if (context == null) {
+				context = new SDCDSystemContext();
+				analysisResult.SystemContext = context;
+			}
 			using (var readelf = await ProcessRunner.Run("readelf", new DirectoryInfo(coredump.DirectoryName), "-n", coredump.FullName)) {
-				SDCDSystemContext context = analysisResult.SystemContext as SDCDSystemContext ?? new SDCDSystemContext();
 				context.Modules = RetrieveLibsFromReadelfOutput(readelf.StdOut).ToList();
 			}
 		}

--- a/src/SuperDump.Analyzer.Linux/Program.cs
+++ b/src/SuperDump.Analyzer.Linux/Program.cs
@@ -4,6 +4,7 @@ using SuperDump.Analyzer.Linux.Boundary;
 using SuperDump.Analyzer.Linux.Analysis;
 using System.Collections.Generic;
 using SuperDump.Common;
+using Thinktecture.IO;
 
 namespace SuperDump.Analyzer.Linux {
 	public class Program {
@@ -23,15 +24,14 @@ namespace SuperDump.Analyzer.Linux {
 					Console.WriteLine($"Invalid argument count! {EXPECTED_COMMAND}");
 					return LinuxAnalyzerExitCode.InvalidArguments.Code;
 				}
-				Prepare(arguments[0]);
+				return Prepare(arguments[0]).Code;
 			} else {
 				if(arguments.Count != 2) {
 					Console.WriteLine($"Invalid argument count! {EXPECTED_COMMAND}");
-					return (int) LinuxAnalyzerExitCode.InvalidArguments.Code;
+					return LinuxAnalyzerExitCode.InvalidArguments.Code;
 				}
 				return RunAnalysis(arguments[0], arguments[1]).Code;
 			}
-			return 1;
 		}
 
 		public static (IList<string>,IList<string>) GetCommands(string[] args) {
@@ -53,8 +53,9 @@ namespace SuperDump.Analyzer.Linux {
 			return analysis.Result;
 		}
 
-		private static void Prepare(string input) {
-			new CoreDumpAnalyzer(archiveHandler, filesystem, processHandler, requestHandler).Prepare(input);
+		private static LinuxAnalyzerExitCode Prepare(string input) {
+			IFileInfo file = new CoreDumpAnalyzer(archiveHandler, filesystem, processHandler, requestHandler).Prepare(input);
+			return file == null ? LinuxAnalyzerExitCode.NoCoredumpFound : LinuxAnalyzerExitCode.Success;
 		}
 	}
 }

--- a/src/SuperDump.Common/LinuxAnalyzerExitCode.cs
+++ b/src/SuperDump.Common/LinuxAnalyzerExitCode.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SuperDump.Common {
+	public sealed class LinuxAnalyzerExitCode {
+
+		private static readonly Dictionary<int, LinuxAnalyzerExitCode> instance = new Dictionary<int, LinuxAnalyzerExitCode>();
+
+		public readonly int Code;
+		public readonly string Message;
+
+		public LinuxAnalyzerExitCode(int code, string message) {
+			this.Code = code;
+			this.Message = message;
+			instance[code] = this;
+		}
+
+		public static readonly LinuxAnalyzerExitCode Success = new LinuxAnalyzerExitCode(0, "");
+		public static readonly LinuxAnalyzerExitCode InvalidArguments = new LinuxAnalyzerExitCode(2, "Invalid analyzation call. Please verify the call arguments in the SuperDump settings.");
+		public static readonly LinuxAnalyzerExitCode NoCoredumpFound = new LinuxAnalyzerExitCode(3, "Could not find a coredump.");
+		public static readonly LinuxAnalyzerExitCode FileNoteMissing = new LinuxAnalyzerExitCode(4, "Cannot analyze dumps without NT_FILE note. This note is only present in more recent kernel releases.");
+		public static readonly LinuxAnalyzerExitCode UnknownCode = new LinuxAnalyzerExitCode(-1, "An unknown error occurred during the analysis. Please check the log files for more details.");
+
+		public static explicit operator LinuxAnalyzerExitCode(int code) {
+			if (instance.TryGetValue(code, out LinuxAnalyzerExitCode result))
+				return result;
+			else
+				return UnknownCode;
+		}
+	}
+}

--- a/src/SuperDump.Common/LinuxAnalyzerExitCode.cs
+++ b/src/SuperDump.Common/LinuxAnalyzerExitCode.cs
@@ -23,10 +23,11 @@ namespace SuperDump.Common {
 		public static readonly LinuxAnalyzerExitCode UnknownCode = new LinuxAnalyzerExitCode(-1, "An unknown error occurred during the analysis. Please check the log files for more details.");
 
 		public static explicit operator LinuxAnalyzerExitCode(int code) {
-			if (instance.TryGetValue(code, out LinuxAnalyzerExitCode result))
+			if (instance.TryGetValue(code, out LinuxAnalyzerExitCode result)) {
 				return result;
-			else
+			} else {
 				return UnknownCode;
+			}
 		}
 	}
 }

--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -138,7 +138,8 @@ namespace SuperDumpService.Services {
 				}
 
 				if (process.ExitCode != 0) {
-					string error = $"Analysis failed with exit code {process.ExitCode}. See log files for more details.";
+					LinuxAnalyzerExitCode exitCode = (LinuxAnalyzerExitCode)process.ExitCode;
+					string error = $"Exit code {process.ExitCode}: {exitCode.Message}";
 					Console.WriteLine(error);
 					throw new Exception(error);
 				}

--- a/src/SuperDumpService/Views/Home/_Summary.cshtml
+++ b/src/SuperDumpService/Views/Home/_Summary.cshtml
@@ -6,7 +6,7 @@
 		<!--anomalies-->
 		@{bool noAnomalies = true;}
 		@if (Model.DumpType == SuperDumpService.Models.DumpType.LinuxCoreDump) {
-			<h5>Process was started with: <b>@(((SuperDump.Models.SDCDSystemContext)Model.Result.SystemContext).Args)</b></h5>
+			<h5>Process was started with: <b>@((Model.Result.SystemContext as SuperDump.Models.SDCDSystemContext)?.Args)</b></h5>
 		}
 		@if (Model.Result.LastEvent != null) {
 			noAnomalies = false;

--- a/src/SuperDumpService/Views/Home/_Threads.cshtml
+++ b/src/SuperDumpService/Views/Home/_Threads.cshtml
@@ -181,12 +181,12 @@
 												</td>
 											}
 											<td class="nobreak stackvariables">
-												@if (Model.DumpType == SuperDumpService.Models.DumpType.LinuxCoreDump) {
+												@if (frame is SuperDumpModels.SDCDCombinedStackFrame) {
 													<table>
-														@foreach (var entry in ((SuperDumpModels.SDCDCombinedStackFrame)frame).Args) {
+														@foreach (var entry in (frame as SuperDumpModels.SDCDCombinedStackFrame).Args) {
 															<tr><td style="width:120px"><b>@(entry.Key)</b></td><td>@(entry.Value)</td></tr>
 														}
-														@foreach (var entry in ((SuperDumpModels.SDCDCombinedStackFrame)frame).Locals) {
+														@foreach (var entry in (frame as SuperDumpModels.SDCDCombinedStackFrame).Locals) {
 															<tr><td style="width:120px"><b>@(entry.Key)</b></td><td>@(entry.Value)</td></tr>
 														}
 													</table>


### PR DESCRIPTION
Fixed:

- Old coredump analysis results cannot be displayed
- GDB analysis gets stuck on dumps with lots of threads
- No results are written for coredumps that don't contain the NT_FILE note (older kernels did not write this note). With this patch, the linux analysis exit code describes the error that happened.