### PR TITLE
Support different visual studio editions

### DIFF
--- a/building/build.cmd
+++ b/building/build.cmd
@@ -1,6 +1,6 @@
 cd /d %~dp0
 
-set msb="C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
+set msb="%VSINSTALLDIR%\MSBuild\15.0\Bin\MSBuild.exe"
 @IF NOT EXIST %msb% @ECHO COULDN'T FIND MSBUILD: %msb% (Is VS2017 installed?)
 
 %msb% msbuild.targets /l:FileLogger,Microsoft.Build.Engine;logfile=msbuild.log


### PR DESCRIPTION
Allow Visual studio enterprise to be used as build environment by making use of the %VSINSTALLDIR% environment variable instead of hard coding the path to visual studio