### PR TITLE
Support windows only and linux builds

### DIFF
--- a/building/build.cmd
+++ b/building/build.cmd
@@ -3,7 +3,10 @@ cd /d %~dp0
 set msb="C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
 @IF NOT EXIST %msb% @ECHO COULDN'T FIND MSBUILD: %msb% (Is VS2017 installed?)
 
-%msb% msbuild.targets /l:FileLogger,Microsoft.Build.Engine;logfile=msbuild.log
+set target="Windows"
+if not "%1" == "" ( set target="%1" )
+
+%msb% msbuild.targets /l:FileLogger,Microsoft.Build.Engine;logfile=msbuild.log /target:%target%
 
 REM ugly hack for a bug in VS2017 (SuperDumpService.xml documentation not included in publishing)
 REM missing SuperDumpService.xml breaks swashbuckle

--- a/building/msbuild.targets
+++ b/building/msbuild.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Project DefaultTargets="Rebuild" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Windows" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)\..</RootFolder>
@@ -11,16 +11,24 @@
 		<UnwindWrapperSources Include="$(RootFolder)\src\LibunwindWrapper\*.cpp;$(RootFolder)\src\LibunwindWrapper\*.h"/>
 	</ItemGroup>
 	
-	<Target Name="Rebuild">
-		<CallTarget Targets="BuildAll"/>
+	<Target Name="All">
+		<CallTarget Targets="Windows"/>
+		<CallTarget Targets="Linux"/>
 	</Target>
 	
-	<Target Name="BuildAll">
+	<Target Name="Windows">
 		<MSBuild Projects="$(RootFolder)\src\SuperDumpModels\SuperDumpModels.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU" Targets="Build"/>
 		<MSBuild Projects="$(RootFolder)\src\SuperDump\SuperDump.csproj" Properties="Configuration=$(Configuration);Platform=x86;OutputPath=$(RootFolder)\build\bin\SuperDumpx86" Targets="Build" />
 		<MSBuild Projects="$(RootFolder)\src\SuperDump\SuperDump.csproj" Properties="Configuration=$(Configuration);Platform=x64;OutputPath=$(RootFolder)\build\bin\SuperDumpx64" Targets="Build" />
 		<MSBuild Projects="$(RootFolder)\src\SuperDumpSelector\SuperDumpSelector.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU;OutputPath=$(RootFolder)\build\bin\SuperDumpSelector" Targets="Build" />
+
+		<MSBuild Projects="$(RootFolder)\src\SuperDumpService\SuperDumpService.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU" Targets="Build" />
+		<MSBuild Projects="$(RootFolder)\src\SuperDumpService\SuperDumpService.csproj" Properties="DeployOnBuild=true;PublishProfile=FolderProfile" />
 		
+		<MSBuild Projects="$(RootFolder)\src\SuperDump.DebugDiag\SuperDump.DebugDiag.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU;OutputPath=$(RootFolder)\build\bin\SuperDump.DebugDiag" Targets="Build" />
+	</Target>
+
+	<Target Name="Linux">
 		<!-- Linux Build -->
 		<Copy SourceFiles="@(UnwindWrapperSources)" DestinationFolder="$(RootFolder)\build\bin\LibunwindWrapper"/>
 		<Copy SourceFiles="$(RootFolder)\src\SuperDump.Analyzer.Linux\Dockerfile.Linux" DestinationFolder="$(RootFolder)\build\bin"/>
@@ -29,11 +37,6 @@
 		<Copy SourceFiles="$(RootFolder)\src\SuperDump.Analyzer.Linux\gdb.sh" DestinationFolder="$(RootFolder)\build\bin\SuperDump.Analyzer.Linux"/>
 		<MSBuild Projects="$(RootFolder)\src\SuperDump.Analyzer.Linux\SuperDump.Analyzer.Linux.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU;DeployOnBuild=true;PublishDir=$(RootFolder)\build\bin\SuperDump.Analyzer.Linux\" Targets="Publish" />
 		<Exec Command="docker build -f Dockerfile.Linux -t sdlinux:dev ./" WorkingDirectory="$(RootFolder)\build\bin"/>
-		
-		<MSBuild Projects="$(RootFolder)\src\SuperDumpService\SuperDumpService.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU" Targets="Build" />
-		<MSBuild Projects="$(RootFolder)\src\SuperDumpService\SuperDumpService.csproj" Properties="DeployOnBuild=true;PublishProfile=FolderProfile" />
-		
-		<MSBuild Projects="$(RootFolder)\src\SuperDump.DebugDiag\SuperDump.DebugDiag.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU;OutputPath=$(RootFolder)\build\bin\SuperDump.DebugDiag" Targets="Build" />
 	</Target>
 	
 	<Target Name="BuildAllx86">


### PR DESCRIPTION
Support building with and without linux (i.e. docker) as part of build arguments

"building/build.cmd" will perform a windows only build (i'm assuming people
running this system are likely to be windows orientated

"building/build.cmd linux" specifies target to include the docker components