### PR TITLE
Search Environment paths for extensions.

### DIFF
--- a/src/SuperDump/Analyzers/WinDbgAnalyzer.cs
+++ b/src/SuperDump/Analyzers/WinDbgAnalyzer.cs
@@ -53,22 +53,15 @@ namespace SuperDump.Analyzers {
 		}
 
 		private static void LoadExtensions(IDebugControl6 debugControl) {
-			if (Environment.Is64BitProcess) {
-				LoadExtension(debugControl, @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\winext\ext.dll"); // do we need this configurable? should we ship these?
-				LoadExtension(debugControl, @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\WINXP\exts.dll");
-				LoadExtension(debugControl, @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\WINXP\uext.dll");
-				LoadExtension(debugControl, @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\WINXP\ntsdexts.dll");
-			} else {
-				LoadExtension(debugControl, @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\winext\ext.dll"); // do we need this configurable? should we ship these?
-				LoadExtension(debugControl, @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\WINXP\exts.dll");
-				LoadExtension(debugControl, @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\WINXP\uext.dll");
-				LoadExtension(debugControl, @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\WINXP\ntsdexts.dll");
-			}
+			LoadExtension(debugControl, @"ext.dll");
+			LoadExtension(debugControl, @"exts.dll");
+			LoadExtension(debugControl, @"uext.dll");
+			LoadExtension(debugControl, @"ntsdexts.dll");
 		}
 
 		private static ulong LoadExtension(IDebugControl6 debugControl, string path) {
 			ulong handle;
-			LogOnErrorHR(debugControl.AddExtension("\"" + path + "\"", 0, out handle), $"failed to load '{path}'");
+			LogOnErrorHR(debugControl.AddExtension(path, 0, out handle), $"failed to load '{path}'");
 			return handle;
 		}
 

--- a/src/SuperDump/Program.cs
+++ b/src/SuperDump/Program.cs
@@ -16,6 +16,11 @@ namespace SuperDump {
 		private static DataTarget target;
 
 		private static int Main(string[] args) {
+			if (Environment.Is64BitProcess) {
+				Environment.SetEnvironmentVariable("_NT_DEBUGGER_EXTENSION_PATH", @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\WINXP;C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\winext;C:\Program Files (x86)\Windows Kits\10\Debuggers\x64;");
+			} else {
+				Environment.SetEnvironmentVariable("_NT_DEBUGGER_EXTENSION_PATH", @"C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\WINXP;C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\winext;C:\Program Files (x86)\Windows Kits\10\Debuggers\x86;");
+			}
 			using (context = new DumpContext()) {
 				Console.WriteLine("SuperDump - Windows dump analysis tool");
 				Console.WriteLine("--------------------------");


### PR DESCRIPTION
This also fixes the fact uext.dll seems to have moved from winxp->winext
in latest debugging tools

(P.S. I'm not sure i've got linefeeds correct on these PR's! Using git
for both linux+windows dev)