### PR TITLE
Allow Visual studio enterprise to be used as build environment 

### DIFF
--- a/building/build.cmd
+++ b/building/build.cmd
@@ -1,13 +1,29 @@
+@echo off
+set VS_REGKEY="HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7"
+set VS_VERSION="15.0"
+
 cd /d %~dp0
 
-set msb="C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
-@IF NOT EXIST %msb% @ECHO COULDN'T FIND MSBUILD: %msb% (Is VS2017 installed?)
+for /F "usebackq skip=2 tokens=1-2*" %%A in (`REG QUERY %VS_REGKEY% /v %VS_VERSION% 2^>nul`) do (
+    set VS_PATH=%%C
+)
 
+if not defined VS_PATH (
+    echo No Visual Studio installation found!
+    exit /B 1
+)
+echo Using Visual Studio installation found at %VS_PATH% for build
+
+set MSBUILD="%VS_PATH%\MSBuild\15.0\Bin\msbuild.exe"
 set target="Windows"
 if not "%1" == "" ( set target="%1" )
 
-%msb% msbuild.targets /l:FileLogger,Microsoft.Build.Engine;logfile=msbuild.log /target:%target%
-
-REM ugly hack for a bug in VS2017 (SuperDumpService.xml documentation not included in publishing)
-REM missing SuperDumpService.xml breaks swashbuckle
-copy "..\src\SuperDumpService\bin\Release\netcoreapp1.1\SuperDumpService.xml" "..\build\bin\SuperDumpService\SuperDumpService.xml"
+if exist %MSBUILD% (
+    %MSBUILD% msbuild.targets /l:FileLogger,Microsoft.Build.Engine;logfile=msbuild.log /target:%target%
+    REM ugly hack for a bug in VS2017 (SuperDumpService.xml documentation not included in publishing)
+    REM missing SuperDumpService.xml breaks swashbuckle
+    copy "..\src\SuperDumpService\bin\Release\netcoreapp1.1\SuperDumpService.xml" "..\build\bin\SuperDumpService\SuperDumpService.xml"
+) else (
+    echo Could not find msbuild.exe at %MSBUILD% (Is Visual Studio installed?)
+    exit /B 1
+)


### PR DESCRIPTION
Allow Visual studio enterprise to be used as build environment by making
use of the %VSINSTALLDIR% environment variable instead of hard coding
the path to visual studio