### PR TITLE
Add leading "lib" prefix for NodeJs extensions

### DIFF
--- a/src/SuperDump.Analyzer.Linux/Analysis/DebugSymbolResolver.cs
+++ b/src/SuperDump.Analyzer.Linux/Analysis/DebugSymbolResolver.cs
@@ -114,7 +114,7 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 		}
 
 		public static string DebugFileName(string path) {
-			return $"{Path.GetFileNameWithoutExtension(path)}.dbg";
+			return $"{(Path.GetExtension(path).Equals(".node") ? "lib" : "")}{Path.GetFileNameWithoutExtension(path)}.dbg";
 		}
 	}
 }


### PR DESCRIPTION
We strip the "lib" prefix for our NodeJs extensions after build therefore downloading of the .dbg file fails currently as the dbg file has still the lib prefix. Therefore the missing "lib" prefix should be added to allow superdump to download the correct file.