### PR TITLE
add cookie security flag and antiforgery validation

### DIFF
--- a/src/SuperDumpService/Controllers/HomeController.cs
+++ b/src/SuperDumpService/Controllers/HomeController.cs
@@ -19,6 +19,7 @@ using SuperDumpService.Services;
 using SuperDumpService.ViewModels;
 
 namespace SuperDumpService.Controllers {
+	[AutoValidateAntiforgeryToken]
 	[Authorize(Policy = LdapCookieAuthenticationExtension.ViewerPolicy)]
 	public class HomeController : Controller {
 		private IHostingEnvironment environment;

--- a/src/SuperDumpService/Controllers/LoginController.cs
+++ b/src/SuperDumpService/Controllers/LoginController.cs
@@ -11,6 +11,7 @@ using SuperDumpService.Services;
 using SuperDumpService.ViewModels;
 
 namespace SuperDumpService.Controllers {
+	[AutoValidateAntiforgeryToken]
 	public class LoginController : Controller {
 		private readonly LdapAuthentcationService authentificationHelper;
 		private readonly ILogger logger;

--- a/src/SuperDumpService/Controllers/SimilarityController.cs
+++ b/src/SuperDumpService/Controllers/SimilarityController.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using SuperDumpService.Helpers;
 
 namespace SuperDumpService.Controllers {
+	[AutoValidateAntiforgeryToken]
 	[Authorize(Policy = LdapCookieAuthenticationExtension.AdminPolicy)]
 	public class SimilarityController : Controller {
 

--- a/src/SuperDumpService/Helpers/LdapCookieAuthenticationExtension.cs
+++ b/src/SuperDumpService/Helpers/LdapCookieAuthenticationExtension.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using SuperDumpService.Models;
@@ -31,6 +32,7 @@ namespace SuperDumpService.Helpers {
 					options.SlidingExpiration = true;
 					options.ExpireTimeSpan = TimeSpan.FromDays(configuration.CookieExpireTimeSpanInDays);
 					options.Cookie.HttpOnly = true;
+					options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
 
 					options.LoginPath = pathOptions.LoginPath;
 					options.LogoutPath = pathOptions.LogoutPath;

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -76,6 +76,8 @@ namespace SuperDumpService {
 				services.AddSingleton(typeof(IAuthorizationHelper), typeof(NoAuthorizationHelper));
 			}
 
+			services.AddAntiforgery();
+
 			//configure DB
 			if (Configuration.GetValue<bool>("UseInMemoryHangfireStorage")) {
 				services.AddHangfire(x => x.UseStorage(new Hangfire.MemoryStorage.MemoryStorage()));

--- a/src/SuperDumpService/Views/Home/Create.cshtml
+++ b/src/SuperDumpService/Views/Home/Create.cshtml
@@ -42,6 +42,7 @@
 					<button class="btn btn-default" type="submit" id="uploadBtnSubmit">
 						<span class="glyphicon glyphicon-upload"></span> Go!
 					</button>
+					<span class="af-token">@Html.AntiForgeryToken()</span>
 				</form>
 			</div>
 			<div class="tab-pane fade" id="local-or-web">

--- a/src/SuperDumpService/wwwroot/js/site.js
+++ b/src/SuperDumpService/wwwroot/js/site.js
@@ -150,6 +150,7 @@ function uploadFile(file) {
 	xhr.open('POST', '/Home/Upload');    // Angeben der URL und des Requesttyps
 
 	var formdata = new FormData();    // Anlegen eines FormData Objekts zum Versenden unserer Datei
+	formdata.append('__RequestVerificationToken', $(".af-token input").val());
 	formdata.append('file', file);  // Anhängen der Datei an das Objekt
 	formdata.append('refurl', $('#refurl').val());
 	formdata.append('note', $('#note').val());


### PR DESCRIPTION
Use CookieSecurePolicy.Always to avoid sending the authentication cookie when not using https. The antiforgery token is now also validated in relevant controllers to avoid Cross Site Request Forgery.