### PR TITLE
improve failed login alert messages and setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Build
 
  The user secrets file can be created by right-clicking the "SuperDumpService" Project in Visual Studio and selecting "Manage User Secrets"
 
+ For the https redirection it is necessary to add urls for https and http to the ASPNETCORE_URLS environment variable.
+
 State of the project
 ====================
 SuperDump has been created at [Dynatrace] as an internship project in 2016. It turned out to be pretty useful so we thought it might be useful for others too. Thus we decided to opensource it.

--- a/build/runsuperdump.cmd
+++ b/build/runsuperdump.cmd
@@ -1,7 +1,7 @@
 cd /d %~dp0
 
 REM adapt port
-SET ASPNETCORE_URLS=https://*5001;http://*:5000
+SET ASPNETCORE_URLS=https://*:5001;http://*:5000
 
 REM adapt asp.netcore environment. "Development" yields better error pages, "Production" is recommended otherwise.
 SET ASPNETCORE_ENVIRONMENT=Development

--- a/build/runsuperdump.cmd
+++ b/build/runsuperdump.cmd
@@ -1,7 +1,7 @@
 cd /d %~dp0
 
 REM adapt port
-SET ASPNETCORE_URLS=http://*:5000
+SET ASPNETCORE_URLS=https://*5001;http://*:5000
 
 REM adapt asp.netcore environment. "Development" yields better error pages, "Production" is recommended otherwise.
 SET ASPNETCORE_ENVIRONMENT=Development

--- a/conf/appsettings.json
+++ b/conf/appsettings.json
@@ -67,7 +67,7 @@
     "InteractiveGdbHost": "http://127.0.0.1:3000", // required for interactive sessions with GDB. The specified host must run a GoTTY instance
     "ElasticSearchHost": "http://127.0.0.1:9200",
     "NodeJsPath": "C:\\Program Files\\nodejs\\node.exe",
-    "UseLdapAuthentication": "true",
+    "UseLdapAuthentication": "true", //requires https
     "UseHttpsRedirection": "true",
     "LdapAuthenticationSettings": {
       //settings in this section that are commented out should be configured using environment variables

--- a/src/SuperDumpService/Controllers/LoginController.cs
+++ b/src/SuperDumpService/Controllers/LoginController.cs
@@ -35,12 +35,12 @@ namespace SuperDumpService.Controllers {
 				return Redirect(loginModel.ReturnUrl);
 			} catch (InvalidCredentialException) {
 				logger.LogFailedLogin("Failed Login", HttpContext, loginModel.Username);
-				loginModel.WrongCredentials = true;
+				loginModel.AlertMessage = "The username or password is incorrect";
 				loginModel.Password = string.Empty;
 				return View(loginModel);
 			} catch (UnauthorizedAccessException) {
 				logger.LogFailedLogin("Login with missing Permissions", HttpContext, loginModel.Username);
-				loginModel.WrongCredentials = true;
+				loginModel.AlertMessage = "You do not have permission to access SuperDump";
 				loginModel.Username = string.Empty;
 				loginModel.Password = string.Empty;
 				return View(loginModel);

--- a/src/SuperDumpService/ViewModels/LoginViewModel.cs
+++ b/src/SuperDumpService/ViewModels/LoginViewModel.cs
@@ -13,6 +13,6 @@ namespace SuperDumpService.ViewModels {
 
 		public bool RememberMe { get; set; }
 
-		public bool WrongCredentials { get; set; }
+		public string AlertMessage { get; set; }
 	}
 }

--- a/src/SuperDumpService/Views/Login/Login.cshtml
+++ b/src/SuperDumpService/Views/Login/Login.cshtml
@@ -6,8 +6,8 @@
 <body>
 	@using (Html.BeginForm("Login", "Login", FormMethod.Post)) {
 		<br />
-		if (Model.WrongCredentials) {
-			<div class=" alert alert-danger">The Login Has Failed!</div>
+		if (!string.IsNullOrEmpty(Model.AlertMessage)) {
+			<div class=" alert alert-danger">@Model.AlertMessage</div>
 		}
 		<input type="hidden" asp-for="ReturnUrl" value="@Model.ReturnUrl" />
 


### PR DESCRIPTION
Added a different login message if the credentials are correct but the user isn't in a SuperDump group. Added a https example url to ASPNETCORE_URLS and updated the authorization section in the README.md to show that requirement.