### PR TITLE
Hangfire deadlock fix

### DIFF
--- a/conf/appsettings.json.template
+++ b/conf/appsettings.json.template
@@ -120,6 +120,7 @@
 
       "JiraApiUsername": "",
       "JiraApiPassword": ""
-    }
+    },
+    "DuplicationDetectionEnabled": "true" // if enabled, the same bundle (md5 hash check) does not get analyzed twice
   }
 }

--- a/src/SuperDumpService/Controllers/AdminController.cs
+++ b/src/SuperDumpService/Controllers/AdminController.cs
@@ -129,7 +129,7 @@ namespace SuperDumpService.Controllers {
 		[HttpPost]
 		public IActionResult PushElasticSearch(bool clean) {
 			logger.LogElasticClean("PushElasticSearch", HttpContext, clean);
-			BackgroundJob.Enqueue(() => elasticService.PushAllResultsAsync(clean));
+			BackgroundJob.Enqueue(() => elasticService.PushAllResults(clean));
 			return View("Overview");
 		}
 	}

--- a/src/SuperDumpService/Controllers/api/DumpsController.cs
+++ b/src/SuperDumpService/Controllers/api/DumpsController.cs
@@ -11,6 +11,7 @@ using System.IO;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using System.Linq;
 
 // For more information on enabling Web API for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -90,7 +91,8 @@ namespace SuperDumpService.Controllers.Api {
 					return BadRequest("Invalid request, resource identifier is not valid or cannot be reached.");
 				}
 			} else {
-				return BadRequest("Invalid request, check if value was set.");
+				var errors = string.Join("; ", ModelState.Values.SelectMany(v => v.Errors).Select(x => "'" + x.Exception.Message + "'"));
+				return BadRequest($"Invalid request, check if value was set: {errors}");
 			}
 		}
 	}

--- a/src/SuperDumpService/Helpers/LocalDBAccess.cs
+++ b/src/SuperDumpService/Helpers/LocalDBAccess.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace SuperDumpService.Helpers {
 	public static class LocalDBAccess {
-		public static SqlConnection GetLocalDB(IConfigurationRoot configuration, string dbName, PathHelper pathHelper, bool deleteIfExists = false) {
+		public static SqlConnection GetLocalDB(IConfiguration configuration, string dbName, PathHelper pathHelper, bool deleteIfExists = false) {
 			try {
 				// todo: need to think about cleanup
 				pathHelper.PrepareDirectories();
@@ -37,7 +37,7 @@ namespace SuperDumpService.Helpers {
 			}
 		}
 
-		private static void DropDatabase(IConfigurationRoot configuration, string dbName) {
+		private static void DropDatabase(IConfiguration configuration, string dbName) {
 			try {
 				using (var tmpConn = new SqlConnection(configuration.GetConnectionString("MasterDB"))) {
 					tmpConn.Open();
@@ -47,7 +47,7 @@ namespace SuperDumpService.Helpers {
 			} catch (SqlException) { }
 		}
 
-		public static bool CreateDatabase(IConfigurationRoot configuration, string dbName, string dbFileName) {
+		public static bool CreateDatabase(IConfiguration configuration, string dbName, string dbFileName) {
 			try {
 				string connectionString = configuration.GetConnectionString("MasterDB");
 				using (var connection = new SqlConnection(connectionString)) {
@@ -67,7 +67,7 @@ namespace SuperDumpService.Helpers {
 			}
 		}
 		
-		public static bool DetachDatabase(IConfigurationRoot configuration, string dbName) {
+		public static bool DetachDatabase(IConfiguration configuration, string dbName) {
 			try {
 				string connectionString = configuration.GetConnectionString("MasterDB");
 				using (var connection = new SqlConnection(connectionString)) {

--- a/src/SuperDumpService/Program.cs
+++ b/src/SuperDumpService/Program.cs
@@ -1,6 +1,9 @@
 ﻿using System.IO;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using SuperDumpService.Helpers;
 
 namespace SuperDumpService {
 	public static class Program {
@@ -13,6 +16,18 @@ namespace SuperDumpService {
 				.UseKestrel(opt => opt.Limits.MaxRequestBodySize = long.MaxValue)
 				.UseContentRoot(Directory.GetCurrentDirectory())
 				.UseIISIntegration()
+				.ConfigureAppConfiguration((hostingContext, config) => {
+					config.SetBasePath(hostingContext.HostingEnvironment.ContentRootPath);
+					config.AddJsonFile(Path.Combine(PathHelper.GetConfDirectory(), "appsettings.json"), optional: false, reloadOnChange: true);
+					config.AddJsonFile(Path.Combine(PathHelper.GetConfDirectory(), $"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json"), optional: true);
+					config.AddEnvironmentVariables();
+					if (hostingContext.HostingEnvironment.IsDevelopment()) {
+						config.AddUserSecrets<Startup>();
+					}
+				})
+				.ConfigureLogging((hostingContext, logging) => {
+					logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+				})
 				.UseStartup<Startup>();
 	}
 }

--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -51,7 +51,11 @@ namespace SuperDumpService.Services {
 		}
 
 		[Hangfire.Queue("analysis", Order = 2)]
-		public async Task Analyze(DumpMetainfo dumpInfo, string dumpFilePath, string analysisWorkingDir) {
+		public void Analyze(DumpMetainfo dumpInfo, string dumpFilePath, string analysisWorkingDir) {
+			AsyncHelper.RunSync(() => AnalyzeAsync(dumpInfo, dumpFilePath, analysisWorkingDir));
+		}
+
+		public async Task AnalyzeAsync(DumpMetainfo dumpInfo, string dumpFilePath, string analysisWorkingDir) {
 			await BlockIfBundleRepoNotReady($"AnalysisService.Analyze for {dumpInfo.Id}");
 
 			try {

--- a/src/SuperDumpService/Services/ElasticSearchService.cs
+++ b/src/SuperDumpService/Services/ElasticSearchService.cs
@@ -48,6 +48,10 @@ namespace SuperDumpService.Services {
 		}
 
 		[Hangfire.Queue("elasticsearch", Order = 3)]
+		public void PushAllResults(bool clean) {
+			AsyncHelper.RunSync(() => PushAllResultsAsync(clean));
+		}
+
 		public async Task PushAllResultsAsync(bool clean) {
 			if (elasticClient == null) {
 				throw new InvalidOperationException("ElasticSearch has not been initialized! Please verify that the settings specify a correct elastic search host.");

--- a/src/SuperDumpService/Services/RelationshipRepository.cs
+++ b/src/SuperDumpService/Services/RelationshipRepository.cs
@@ -60,7 +60,6 @@ namespace SuperDumpService.Services {
 			}
 		}
 
-
 		private async Task UpdateSimilarity0(DumpIdentifier dumpA, DumpIdentifier dumpB, double similarity) {
 			if (relationShips.TryGetValue(dumpA, out IDictionary<DumpIdentifier, double> relationShip)) {
 				await UpdateRelationship(dumpA, dumpB, similarity, relationShip);

--- a/src/SuperDumpService/Services/SimilarityService.cs
+++ b/src/SuperDumpService/Services/SimilarityService.cs
@@ -97,7 +97,11 @@ namespace SuperDumpService.Services {
 		}
 
 		[Hangfire.Queue("similarityanalysis", Order = 3)]
-		public async Task CalculateSimilarity(DumpMetainfo dumpA, bool force, DateTime timeFrom) {
+		public void CalculateSimilarity(DumpMetainfo dumpA, bool force, DateTime timeFrom) {
+			AsyncHelper.RunSync(() => CalculateSimilarityAsync(dumpA, force, timeFrom));
+		}
+
+		public async Task CalculateSimilarityAsync(DumpMetainfo dumpA, bool force, DateTime timeFrom) {
 			try {
 				var swTotal = new Stopwatch();
 				swTotal.Start();

--- a/src/SuperDumpService/Services/SuperDumpRepository.cs
+++ b/src/SuperDumpService/Services/SuperDumpRepository.cs
@@ -164,7 +164,11 @@ namespace SuperDumpService.Services {
 		}
 
 		[Hangfire.Queue("download", Order = 1)]
-		public async Task DownloadAndScheduleProcessFile(string bundleId, string url, string filename) {
+		public void DownloadAndScheduleProcessFile(string bundleId, string url, string filename) {
+			AsyncHelper.RunSync(() => DownloadAndScheduleProcessFileAsync(bundleId, url, filename));
+		}
+
+		public async Task DownloadAndScheduleProcessFileAsync(string bundleId, string url, string filename) {
 			bundleRepo.SetBundleStatus(bundleId, BundleStatus.Downloading);
 			try {
 				using (TempDirectoryHandle tempDir = await downloadService.Download(bundleId, url, filename)) {

--- a/src/SuperDumpService/Services/SuperDumpRepository.cs
+++ b/src/SuperDumpService/Services/SuperDumpRepository.cs
@@ -168,7 +168,7 @@ namespace SuperDumpService.Services {
 			bundleRepo.SetBundleStatus(bundleId, BundleStatus.Downloading);
 			try {
 				using (TempDirectoryHandle tempDir = await downloadService.Download(bundleId, url, filename)) {
-					if (!SetHashAndCheckIfDuplicated(bundleId, new FileInfo(Path.Combine(tempDir.Dir.FullName, filename)))) {
+					if (settings.Value.DuplicationDetectionEnabled && !SetHashAndCheckIfDuplicated(bundleId, new FileInfo(Path.Combine(tempDir.Dir.FullName, filename)))) {
 						// duplication detected
 						return;
 					}

--- a/src/SuperDumpService/SuperDumpSettings.cs
+++ b/src/SuperDumpService/SuperDumpSettings.cs
@@ -37,5 +37,6 @@ namespace SuperDumpService {
 		public bool UseJiraIntegration { get; set; }
 		public JiraIntegrationSettings JiraIntegrationSettings { get; set; }
 		public bool UseAllRequestLogging { get; set; }
+		public bool DuplicationDetectionEnabled { get; set; }
 	}
 }


### PR DESCRIPTION
We've encountered a number of nasty deadlocks, which only happened after a few days, mostly under very high load. The deadlock manifested by stuck transactions on "Overview" and "Result" requests and it turned out hundreds of threads were stuck in waiting for Semaphores/WaitHandles/ManualResetEvents in System.Threading/Task namespaces.

Here are all stacks: https://gist.github.com/discostu105/adb41868e60157edc7b8fa454bc2873d

The most suspicious one:

    [GCFrame: 0000006339e7db90] 
    [HelperMethodFrame_1OBJ: 0000006339e7dcd8] System.Threading.Monitor.ObjWait(Boolean, Int32, System.Object)
    System.Threading.ManualResetEventSlim.Wait(Int32, System.Threading.CancellationToken)
    System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, System.Threading.CancellationToken) [E:\A\_work\164\s\src\mscorlib\src\System\Threading\Tasks\Task.cs @ 2978]
    System.Threading.Tasks.Task.InternalWaitCore(Int32, System.Threading.CancellationToken) [E:\A\_work\164\s\src\mscorlib\src\System\Threading\Tasks\Task.cs @ 2917]
    System.Threading.Tasks.Task.Wait(Int32, System.Threading.CancellationToken) [E:\A\_work\164\s\src\mscorlib\src\System\Threading\Tasks\Task.cs @ 2818]
    Hangfire.Server.CoreBackgroundJobPerformer.InvokeMethod()
    Hangfire.Server.CoreBackgroundJobPerformer.Perform()
    Hangfire.Server.BackgroundJobPerformer+c__DisplayClass8_0.b__0()
    Hangfire.Server.BackgroundJobPerformer.InvokePerformFilter()
    Hangfire.Server.BackgroundJobPerformer.PerformJobWithFilters()
    Hangfire.Server.BackgroundJobPerformer.Perform()
    Hangfire.Server.Worker.PerformJob()
    Hangfire.Server.Worker.Execute()
    Hangfire.Server.AutomaticRetryProcess.Execute()
    Hangfire.Server.InfiniteLoopProcess.Execute()
    Hangfire.Server.ServerProcessExtensions.RunProcess()
    System.Threading.Tasks.Task.InnerInvoke() [E:\A\_work\164\s\src\mscorlib\src\System\Threading\Tasks\Task.cs @ 2495]
    System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object) [E:\A\_work\164\s\src\mscorlib\shared\System\Threading\ExecutionContext.cs @ 167]
    System.Threading.Tasks.Task.ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef) [E:\A\_work\164\s\src\mscorlib\src\System\Threading\Tasks\Task.cs @ 2440]
    System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object) [E:\A\_work\164\s\src\mscorlib\shared\System\Threading\ExecutionContext.cs @ 167]
    [GCFrame: 0000006339e7e808] 
    [DebuggerU2MCatchHandlerFrame: 0000006339e7ea80]

We're assuming the `.Wait()` call here causes this: https://github.com/HangfireIO/Hangfire/blob/master/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs#L113

This is just a hunch, and not fully proven yet.

The fix is to only schedule regular sync methods in hangfire and invoke the async methods via AsyncHelper.