### PR TITLE
Some cleanups

### DIFF
--- a/src/SuperDumpService/Controllers/HomeController.cs
+++ b/src/SuperDumpService/Controllers/HomeController.cs
@@ -25,7 +25,7 @@ namespace SuperDumpService.Controllers {
 		public SuperDumpRepository superDumpRepo;
 		public BundleRepository bundleRepo;
 		public DumpRepository dumpRepo;
-		public DumpStorageFilebased dumpStorage;
+		public IDumpStorage dumpStorage;
 		public SuperDumpSettings settings;
 		private readonly PathHelper pathHelper;
 		private readonly RelationshipRepository relationshipRepo;
@@ -39,7 +39,7 @@ namespace SuperDumpService.Controllers {
 				SuperDumpRepository superDumpRepo, 
 				BundleRepository bundleRepo, 
 				DumpRepository dumpRepo,
-				DumpStorageFilebased dumpStorage, 
+				IDumpStorage dumpStorage, 
 				IOptions<SuperDumpSettings> settings, 
 				PathHelper pathHelper, 
 				RelationshipRepository relationshipRepo, 

--- a/src/SuperDumpService/Controllers/HomeController.cs
+++ b/src/SuperDumpService/Controllers/HomeController.cs
@@ -227,7 +227,8 @@ namespace SuperDumpService.Controllers {
 			}
 
 			logger.LogDumpAccess("Start Interactive Mode", HttpContext, bundleInfo, dumpId);
-			return View(new InteractiveViewModel() { BundleId = bundleId, DumpId = dumpId, DumpInfo = dumpRepo.Get(bundleId, dumpId), Command = cmd });
+			var id = new DumpIdentifier(bundleId, dumpId);
+			return View(new InteractiveViewModel() { Id = id, DumpInfo = dumpRepo.Get(id), Command = cmd });
 		}
 
 		[HttpGet(Name = "Report")]
@@ -241,9 +242,9 @@ namespace SuperDumpService.Controllers {
 				return View(null);
 			}
 
-			var dumpInfo = superDumpRepo.GetDump(bundleId, dumpId);
+			var dumpInfo = superDumpRepo.GetDump(id);
 			if (dumpInfo == null) {
-				logger.LogNotFound("Report: Dump not found", HttpContext, "DumpId", dumpId);
+				logger.LogNotFound("Report: Dump not found", HttpContext, "Id", id.ToString());
 				return View(null);
 			}
 
@@ -263,13 +264,13 @@ namespace SuperDumpService.Controllers {
 				(await relationshipRepo.GetRelationShips(new DumpIdentifier(bundleId, dumpId)))
 					.Select(x => new KeyValuePair<DumpMetainfo, double>(dumpRepo.Get(x.Key), x.Value)).Where(dump => dump.Key != null);
 
-			return base.View(new ReportViewModel(bundleId, dumpId) {
+			return base.View(new ReportViewModel(id) {
 				BundleFileName = bundleInfo.BundleFileName,
 				DumpFileName = dumpInfo.DumpFileName,
 				Result = res,
 				CustomProperties = Utility.Sanitize(bundleInfo.CustomProperties),
 				TimeStamp = dumpInfo.Created,
-				Files = dumpRepo.GetFileNames(bundleId, dumpId),
+				Files = dumpRepo.GetFileNames(id),
 				AnalysisError = dumpInfo.ErrorMessage,
 				ThreadTags = res != null ? res.GetThreadTags() : new HashSet<SDTag>(),
 				PointerSize = res == null ? 8 : (res.SystemContext?.ProcessArchitecture == "X86" ? 8 : 12),
@@ -280,7 +281,7 @@ namespace SuperDumpService.Controllers {
 				InteractiveGdbHost = settings.InteractiveGdbHost,
 				SimilarityDetectionEnabled = settings.SimilarityDetectionEnabled,
 				Similarities = similarDumps,
-				IsDumpAvailable = dumpRepo.IsPrimaryDumpAvailable(bundleId, dumpId),
+				IsDumpAvailable = dumpRepo.IsPrimaryDumpAvailable(id),
 				MainBundleJiraIssues = !settings.UseJiraIntegration || !jiraIssueRepository.IsPopulated ? Enumerable.Empty<JiraIssueModel>() : await jiraIssueRepository.GetAllIssuesByBundleIdWithoutWait(bundleId),
 				SimilarDumpIssues = !settings.UseJiraIntegration || !jiraIssueRepository.IsPopulated ? new Dictionary<string, IEnumerable<JiraIssueModel>>() : await jiraIssueRepository.GetAllIssuesByBundleIdsWithoutWait(similarDumps.Select(dump => dump.Key.BundleId)),
 				UseJiraIntegration = settings.UseJiraIntegration,
@@ -293,7 +294,7 @@ namespace SuperDumpService.Controllers {
 		private async Task<string> ReadCustomTextResult(DumpMetainfo dumpInfo) {
 			SDFileEntry customResultFile = dumpInfo.Files.FirstOrDefault(x => x.Type == SDFileType.CustomTextResult);
 			if (customResultFile == null) return null;
-			FileInfo file = dumpStorage.GetFile(dumpInfo.BundleId, dumpInfo.DumpId, customResultFile.FileName);
+			FileInfo file = dumpStorage.GetFile(dumpInfo.Id, customResultFile.FileName);
 			if (file == null || !file.Exists) return null;
 			return await System.IO.File.ReadAllTextAsync(file.FullName);
 		}
@@ -318,7 +319,7 @@ namespace SuperDumpService.Controllers {
 				logger.LogNotFound("DownloadFile: Bundle not found", HttpContext, "BundleId", bundleId);
 				return View(null);
 			}
-			var file = dumpStorage.GetFile(bundleId, dumpId, filename);
+			var file = dumpStorage.GetFile(new DumpIdentifier(bundleId, dumpId), filename);
 			if (file == null) {
 				logger.LogNotFound("DownloadFile: File not found", HttpContext, "Filename", filename);
 				throw new ArgumentException("could not find file");
@@ -337,7 +338,7 @@ namespace SuperDumpService.Controllers {
 		/// When normally requesting this, the content is direclty shown in the browser.
 		/// </summary>
 		private IActionResult ContentWithFilename(string content, string filename) {
-			ContentDisposition cd = new ContentDisposition {
+			var cd = new ContentDisposition {
 				FileName = filename,
 				Inline = true  // false = prompt the user for downloading;  true = browser to try to show the file inline
 			};
@@ -355,8 +356,9 @@ namespace SuperDumpService.Controllers {
 				return View(null);
 			}
 			logger.LogDumpAccess("Rerun", HttpContext, bundleInfo, dumpId);
-			superDumpRepo.RerunAnalysis(bundleId, dumpId);
-			return View(new ReportViewModel(bundleId, dumpId));
+			var id = new DumpIdentifier(bundleId, dumpId);
+			superDumpRepo.RerunAnalysis(id);
+			return View(new ReportViewModel(id));
 		}
 	}
 }

--- a/src/SuperDumpService/Helpers/PathHelper.cs
+++ b/src/SuperDumpService/Helpers/PathHelper.cs
@@ -47,10 +47,6 @@ namespace SuperDumpService.Helpers {
 			return Path.Combine(GetBundleDirectory(id.BundleId), id.DumpId);
 		}
 
-		public string GetDumpDirectory(string bundleId, string dumpId) {
-			return Path.Combine(GetBundleDirectory(bundleId), dumpId);
-		}
-
 		internal string GetDumpMiniInfoPath(DumpIdentifier id) {
 			return Path.Combine(GetDumpDirectory(id), "mini-info.json");
 		}
@@ -72,24 +68,24 @@ namespace SuperDumpService.Helpers {
 			Directory.CreateDirectory(GetHangfireDBDir());
 		}
 
-		public string GetJsonPath(string bundleId, string dumpId) {
-			return Path.Combine(GetDumpDirectory(bundleId, dumpId), "superdump-result.json");
+		public string GetJsonPath(DumpIdentifier id) {
+			return Path.Combine(GetDumpDirectory(id), "superdump-result.json");
 		}
 
-		internal string GetJsonPathFallback(string bundleId, string dumpId) {
-			return Path.Combine(GetDumpDirectory(bundleId, dumpId), dumpId + ".json");
+		internal string GetJsonPathFallback(DumpIdentifier id) {
+			return Path.Combine(GetDumpDirectory(id), id.DumpId + ".json");
 		}
 
 		internal string GetBundleMetadataPath(string bundleId) {
 			return Path.Combine(GetBundleDirectory(bundleId), "bundleinfo.json");
 		}
 
-		internal string GetDumpMetadataPath(string bundleId, string dumpId) {
-			return Path.Combine(GetDumpDirectory(bundleId, dumpId), "dumpinfo.json");
+		internal string GetDumpMetadataPath(DumpIdentifier id) {
+			return Path.Combine(GetDumpDirectory(id), "dumpinfo.json");
 		}
 
-		internal string GetRelationshipsPath(string bundleId, string dumpId) {
-			return Path.Combine(GetDumpDirectory(bundleId, dumpId), "relationships.json");
+		internal string GetRelationshipsPath(DumpIdentifier id) {
+			return Path.Combine(GetDumpDirectory(id), "relationships.json");
 		}
 
 		internal string GetIdenticRelationshipsPath(string bundleId) {

--- a/src/SuperDumpService/Helpers/PathHelper.cs
+++ b/src/SuperDumpService/Helpers/PathHelper.cs
@@ -12,11 +12,11 @@ namespace SuperDumpService.Helpers {
 		private static string confDir = Path.Combine(Directory.GetCurrentDirectory(), @"../../conf/");
 		private static string confDirFallback = Directory.GetCurrentDirectory();
 
-		public PathHelper(IConfigurationSection configurationSection) {
+		public PathHelper(string workingDir, string uploadsDir, string hangfireDbDir) {
 			// maybe there is a smarter way to convert IConfigurationSection to SuperDumpSettings?
-			this.workingDir = configurationSection.GetValue<string>(nameof(SuperDumpSettings.DumpsDir)) ?? Path.Combine(Directory.GetCurrentDirectory(), @"../../data/dumps/");
-			this.uploadsDir = configurationSection.GetValue<string>(nameof(SuperDumpSettings.UploadDir)) ?? Path.Combine(Directory.GetCurrentDirectory(), @"../../data/uploads/");
-			this.hangfireDbDir = configurationSection.GetValue<string>(nameof(SuperDumpSettings.HangfireLocalDbDir)) ?? Path.Combine(Directory.GetCurrentDirectory(), @"../../data/hangfire/");
+			this.workingDir = workingDir;
+			this.uploadsDir = uploadsDir;
+			this.hangfireDbDir = hangfireDbDir;
 		}
 
 		internal static string GetConfDirectory() {

--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -10,7 +10,7 @@ using SuperDump.Models;
 
 namespace SuperDumpService.Services {
 	public class AnalysisService {
-		private readonly DumpStorageFilebased dumpStorage;
+		private readonly IDumpStorage dumpStorage;
 		private readonly DumpRepository dumpRepo;
 		private readonly BundleRepository bundleRepo;
 		private readonly PathHelper pathHelper;
@@ -20,7 +20,7 @@ namespace SuperDumpService.Services {
 		private readonly SimilarityService similarityService;
 
 		public AnalysisService(
-					DumpStorageFilebased dumpStorage,
+					IDumpStorage dumpStorage,
 					DumpRepository dumpRepo,
 					BundleRepository bundleRepo,
 					PathHelper pathHelper,

--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -40,11 +40,11 @@ namespace SuperDumpService.Services {
 		}
 
 		public void ScheduleDumpAnalysis(DumpMetainfo dumpInfo) {
-			string dumpFilePath = dumpStorage.GetDumpFilePath(dumpInfo.BundleId, dumpInfo.DumpId);
-			if (!File.Exists(dumpFilePath)) throw new DumpNotFoundException($"bundleid: {dumpInfo.BundleId}, dumpid: {dumpInfo.DumpId}, path: {dumpFilePath}");
+			string dumpFilePath = dumpStorage.GetDumpFilePath(dumpInfo.Id);
+			if (!File.Exists(dumpFilePath)) throw new DumpNotFoundException($"id: {dumpInfo.Id}, path: {dumpFilePath}");
 
-			string analysisWorkingDir = pathHelper.GetDumpDirectory(dumpInfo.BundleId, dumpInfo.DumpId);
-			if (!Directory.Exists(analysisWorkingDir)) throw new DirectoryNotFoundException($"bundleid: {dumpInfo.BundleId}, dumpid: {dumpInfo.DumpId}, path: {dumpFilePath}");
+			string analysisWorkingDir = pathHelper.GetDumpDirectory(dumpInfo.Id);
+			if (!Directory.Exists(analysisWorkingDir)) throw new DirectoryNotFoundException($"id: {dumpInfo.Id}, path: {dumpFilePath}");
 
 			// schedule actual analysis
 			Hangfire.BackgroundJob.Enqueue<AnalysisService>(repo => Analyze(dumpInfo, dumpFilePath, analysisWorkingDir)); // got a stackoverflow problem here.
@@ -59,7 +59,7 @@ namespace SuperDumpService.Services {
 			await BlockIfBundleRepoNotReady($"AnalysisService.Analyze for {dumpInfo.Id}");
 
 			try {
-				dumpRepo.SetDumpStatus(dumpInfo.BundleId, dumpInfo.DumpId, DumpStatus.Analyzing);
+				dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Analyzing);
 
 				if (dumpInfo.DumpType == DumpType.WindowsDump) {
 					await AnalyzeWindows(dumpInfo, new DirectoryInfo(analysisWorkingDir), dumpFilePath);
@@ -70,23 +70,23 @@ namespace SuperDumpService.Services {
 				}
 
 				// Re-fetch dump info as it was updated
-				dumpInfo = dumpRepo.Get(dumpInfo.BundleId, dumpInfo.DumpId);
+				dumpInfo = dumpRepo.Get(dumpInfo.Id);
 
 				SDResult result = await dumpRepo.GetResultAndThrow(dumpInfo.Id);
 
 				if (result != null) {
 					dumpRepo.WriteResult(dumpInfo.Id, result);
-					dumpRepo.SetDumpStatus(dumpInfo.BundleId, dumpInfo.DumpId, DumpStatus.Finished);
+					dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Finished);
 
 					var bundle = bundleRepo.Get(dumpInfo.BundleId);
 					await elasticSearch.PushResultAsync(result, bundle, dumpInfo);
 				}
 			} catch (Exception e) {
 				Console.WriteLine(e.Message);
-				dumpRepo.SetDumpStatus(dumpInfo.BundleId, dumpInfo.DumpId, DumpStatus.Failed, e.ToString());
+				dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Failed, e.ToString());
 			} finally {
 				if (settings.Value.DeleteDumpAfterAnalysis) {
-					dumpStorage.DeleteDumpFile(dumpInfo.BundleId, dumpInfo.DumpId);
+					dumpStorage.DeleteDumpFile(dumpInfo.Id);
 				}
 				await notifications.NotifyDumpAnalysisFinished(dumpInfo);
 				similarityService.ScheduleSimilarityAnalysis(dumpInfo, false, DateTime.Now - TimeSpan.FromDays(settings.Value.SimilarityDetectionMaxDays));
@@ -99,16 +99,16 @@ namespace SuperDumpService.Services {
 			Console.WriteLine($"launching '{dumpselector}' '{dumpFilePath}'");
 			string[] arguments = {
 				$"--dump \"{dumpFilePath}\"",
-				$"--out \"{pathHelper.GetJsonPath(dumpInfo.BundleId, dumpInfo.DumpId)}\""
+				$"--out \"{pathHelper.GetJsonPath(dumpInfo.Id)}\""
 			};
 			using (var process = await ProcessRunner.Run(dumpselector, workingDir, arguments)) {
 				string selectorLog = $"SuperDumpSelector exited with error code {process.ExitCode}" +
 					$"{Environment.NewLine}{Environment.NewLine}stdout:{Environment.NewLine}{process.StdOut}" +
 					$"{Environment.NewLine}{Environment.NewLine}stderr:{Environment.NewLine}{process.StdErr}";
 				Console.WriteLine(selectorLog);
-				File.WriteAllText(Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.BundleId, dumpInfo.DumpId), "superdumpselector.log"), selectorLog);
+				File.WriteAllText(Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.Id), "superdumpselector.log"), selectorLog);
 				if (process.ExitCode != 0) {
-					dumpRepo.SetDumpStatus(dumpInfo.BundleId, dumpInfo.DumpId, DumpStatus.Failed, selectorLog);
+					dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Failed, selectorLog);
 					throw new Exception(selectorLog);
 				}
 			}
@@ -118,7 +118,7 @@ namespace SuperDumpService.Services {
 
 		private async Task RunDebugDiagAnalysis(DumpMetainfo dumpInfo, DirectoryInfo workingDir, string dumpFilePath) {
 			//--dump = "C:\superdump\data\dumps\hno3391\iwb0664\iwb0664.dmp"--out= "C:\superdump\data\dumps\hno3391\iwb0664\debugdiagout.mht"--symbolPath = "cache*c:\localsymbols;http://msdl.microsoft.com/download/symbols"--overwrite
-			string reportFilePath = Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.BundleId, dumpInfo.DumpId), "DebugDiagAnalysis.mht");
+			string reportFilePath = Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.Id), "DebugDiagAnalysis.mht");
 			string debugDiagExe = "SuperDump.DebugDiag.exe";
 
 			try {
@@ -130,8 +130,8 @@ namespace SuperDumpService.Services {
 						$"{Environment.NewLine}{Environment.NewLine}stdout:{Environment.NewLine}{process.StdOut}" +
 						$"{Environment.NewLine}{Environment.NewLine}stderr:{Environment.NewLine}{process.StdErr}";
 					Console.WriteLine(log);
-					File.WriteAllText(Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.BundleId, dumpInfo.DumpId), "superdump.debugdiag.log"), log);
-					dumpRepo.AddFile(dumpInfo.BundleId, dumpInfo.DumpId, "DebugDiagAnalysis.mht", SDFileType.DebugDiagResult);
+					File.WriteAllText(Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.Id), "superdump.debugdiag.log"), log);
+					dumpRepo.AddFile(dumpInfo.Id, "DebugDiagAnalysis.mht", SDFileType.DebugDiagResult);
 				}
 			} catch (ProcessRunnerException e) {
 				if (e.InnerException is FileNotFoundException) {
@@ -155,8 +155,8 @@ namespace SuperDumpService.Services {
 			command = command.Replace("{dumpdir}", workingDir.FullName);
 			command = command.Replace("{dumppath}", dumpFilePath);
 			command = command.Replace("{dumpname}", Path.GetFileName(dumpFilePath));
-			command = command.Replace("{outputpath}", pathHelper.GetJsonPath(dumpInfo.BundleId, dumpInfo.DumpId));
-			command = command.Replace("{outputname}", Path.GetFileName(pathHelper.GetJsonPath(dumpInfo.BundleId, dumpInfo.DumpId)));
+			command = command.Replace("{outputpath}", pathHelper.GetJsonPath(dumpInfo.Id));
+			command = command.Replace("{outputname}", Path.GetFileName(pathHelper.GetJsonPath(dumpInfo.Id)));
 
 			Utility.ExtractExe(command, out string executable, out string arguments);
 
@@ -166,10 +166,10 @@ namespace SuperDumpService.Services {
 				Console.WriteLine($"stderr: {process.StdErr}");
 
 				if (process.StdOut?.Length > 0) {
-					File.WriteAllText(Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.BundleId, dumpInfo.DumpId), "linux-analysis.log"), process.StdOut);
+					File.WriteAllText(Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.Id), "linux-analysis.log"), process.StdOut);
 				}
 				if (process.StdErr?.Length > 0) {
-					File.WriteAllText(Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.BundleId, dumpInfo.DumpId), "linux-analysis.err.log"), process.StdErr);
+					File.WriteAllText(Path.Combine(pathHelper.GetDumpDirectory(dumpInfo.Id), "linux-analysis.err.log"), process.StdErr);
 				}
 
 				if (process.ExitCode != 0) {

--- a/src/SuperDumpService/Services/BundleStorageFilebased.cs
+++ b/src/SuperDumpService/Services/BundleStorageFilebased.cs
@@ -14,10 +14,10 @@ namespace SuperDumpService.Services {
 	/// this implementation uses simple filebased storage
 	/// </summary>
 	public class BundleStorageFilebased {
-		private readonly DumpStorageFilebased dumpStorage; // use this only for backward compat (populate bundleMetainfo from dumps)
+		private readonly IDumpStorage dumpStorage; // use this only for backward compat (populate bundleMetainfo from dumps)
 		private readonly PathHelper pathHelper;
 
-		public BundleStorageFilebased(DumpStorageFilebased dumpStorage, PathHelper pathHelper) {
+		public BundleStorageFilebased(IDumpStorage dumpStorage, PathHelper pathHelper) {
 			this.dumpStorage = dumpStorage;
 			this.pathHelper = pathHelper;
 		}

--- a/src/SuperDumpService/Services/BundleStorageFilebased.cs
+++ b/src/SuperDumpService/Services/BundleStorageFilebased.cs
@@ -86,7 +86,7 @@ namespace SuperDumpService.Services {
 					metainfo.Created = dump.Created;
 					metainfo.Finished = dump.Created; // can't do better.
 					metainfo.Status = BundleStatus.Finished;
-					var fullresult = await dumpStorage.ReadResults(bundleId, dump.DumpId);
+					var fullresult = await dumpStorage.ReadResults(dump.Id);
 					if (fullresult != null) {
 						if (!string.IsNullOrEmpty(fullresult.AnalysisInfo.JiraIssue)) metainfo.CustomProperties["ref"] = fullresult.AnalysisInfo.JiraIssue;
 						if (!string.IsNullOrEmpty(fullresult.AnalysisInfo.FriendlyName)) metainfo.CustomProperties["note"] = fullresult.AnalysisInfo.FriendlyName;

--- a/src/SuperDumpService/Services/DumpRepository.cs
+++ b/src/SuperDumpService/Services/DumpRepository.cs
@@ -43,10 +43,10 @@ namespace SuperDumpService.Services {
 			dumps.TryAdd(bundleId, dict);
 		}
 
-		public DumpMetainfo Get(string bundleId, string dumpId) {
-			ConcurrentDictionary<string, DumpMetainfo> bundleInfo = dumps.GetValueOrDefault(bundleId);
+		public DumpMetainfo Get(DumpIdentifier id) {
+			ConcurrentDictionary<string, DumpMetainfo> bundleInfo = dumps.GetValueOrDefault(id.BundleId);
 			if (bundleInfo != null) {
-				return bundleInfo.GetValueOrDefault(dumpId);
+				return bundleInfo.GetValueOrDefault(id.DumpId);
 			}
 			return null;
 		}
@@ -54,10 +54,6 @@ namespace SuperDumpService.Services {
 		public IEnumerable<DumpMetainfo> Get(string bundleId) {
 			if (!dumps.ContainsKey(bundleId)) return Enumerable.Empty<DumpMetainfo>();
 			return dumps[bundleId].Values;
-		}
-
-		public DumpMetainfo Get(DumpIdentifier dumpId) {
-			return Get(dumpId.BundleId, dumpId.DumpId);
 		}
 
 		public IEnumerable<DumpMetainfo> GetAll() {
@@ -84,17 +80,15 @@ namespace SuperDumpService.Services {
 			};
 			dict[dumpId] = dumpInfo;
 			dumps.TryAdd(bundleId, dict);
-			storage.Create(bundleId, dumpId);
+			storage.Create(dumpInfo.Id);
 
-			FileInfo destFile = await storage.AddFileCopy(bundleId, dumpId, sourcePath);
-			AddSDFile(bundleId, dumpId, destFile.Name, SDFileType.PrimaryDump);
+			FileInfo destFile = await storage.AddFileCopy(dumpInfo.Id, sourcePath);
+			AddSDFile(dumpInfo.Id, destFile.Name, SDFileType.PrimaryDump);
 			return dumpInfo;
 		}
 
-		internal string GetDumpFilePath(DumpIdentifier id) => GetDumpFilePath(id.BundleId, id.DumpId);
-
-		internal string GetDumpFilePath(string bundleId, string dumpId) {
-			return storage.GetDumpFilePath(bundleId, dumpId);
+		internal string GetDumpFilePath(DumpIdentifier id) {
+			return storage.GetDumpFilePath(id);
 		}
 
 		public void ResetDumpTyp(DumpIdentifier id) {
@@ -107,8 +101,8 @@ namespace SuperDumpService.Services {
 			throw new InvalidDataException($"cannot determine dumptype of {sourcePath.FullName}");
 		}
 
-		private void AddSDFile(string bundleId, string dumpId, string filename, SDFileType type) {
-			var dumpInfo = Get(bundleId, dumpId);
+		private void AddSDFile(DumpIdentifier id, string filename, SDFileType type) {
+			var dumpInfo = Get(id);
 			dumpInfo.Files.Add(new SDFileEntry() {
 				FileName = filename,
 				Type = type
@@ -127,12 +121,8 @@ namespace SuperDumpService.Services {
 			}
 		}
 
-		internal async Task<SDResult> GetResultAndThrow(DumpIdentifier id) => await storage.ReadResultsAndThrow(id.BundleId, id.DumpId);
-		internal async Task<SDResult> GetResult(DumpIdentifier id) => await storage.ReadResults(id.BundleId, id.DumpId);
-
-		internal async Task<SDResult> GetResult(string bundleId, string dumpId) {
-			return await storage.ReadResults(bundleId, dumpId);
-		}
+		internal async Task<SDResult> GetResultAndThrow(DumpIdentifier id) => await storage.ReadResultsAndThrow(id);
+		internal async Task<SDResult> GetResult(DumpIdentifier id) => await storage.ReadResults(id);
 
 		internal bool MiniInfoExists(DumpIdentifier id) {
 			if (miniInfosLazyCache.ContainsKey(id)) return true;
@@ -157,12 +147,12 @@ namespace SuperDumpService.Services {
 			storage.WriteResult(id, result);
 		}
 
-		internal IEnumerable<SDFileInfo> GetFileNames(string bundleId, string dumpId) {
-			return storage.GetSDFileInfos(bundleId, dumpId);
+		internal IEnumerable<SDFileInfo> GetFileNames(DumpIdentifier id) {
+			return storage.GetSDFileInfos(id);
 		}
 
-		internal void SetDumpStatus(string bundleId, string dumpId, DumpStatus status, string errorMessage = null) {
-			var dumpInfo = Get(bundleId, dumpId);
+		internal void SetDumpStatus(DumpIdentifier id, DumpStatus status, string errorMessage = null) {
+			var dumpInfo = Get(id);
 			dumpInfo.Status = status;
 			dumpInfo.ErrorMessage = errorMessage;
 			if (status == DumpStatus.Analyzing) {
@@ -181,18 +171,18 @@ namespace SuperDumpService.Services {
 			storage.Store(dumpInfo);
 		}
 
-		internal async Task<FileInfo> AddFileCopy(string bundleId, string dumpId, FileInfo file, SDFileType type) {
-			var newFile = await storage.AddFileCopy(bundleId, dumpId, file);
-			AddSDFile(bundleId, dumpId, file.Name, type);
+		internal async Task<FileInfo> AddFileCopy(DumpIdentifier id, FileInfo file, SDFileType type) {
+			var newFile = await storage.AddFileCopy(id, file);
+			AddSDFile(id, file.Name, type);
 			return newFile;
 		}
 
-		internal void AddFile(string bundleId, string dumpId, string filename, SDFileType type) {
-			AddSDFile(bundleId, dumpId, filename, type);
+		internal void AddFile(DumpIdentifier id, string filename, SDFileType type) {
+			AddSDFile(id, filename, type);
 		}
 
-		public bool IsPrimaryDumpAvailable(string bundleId, string dumpId) {
-			return File.Exists(GetDumpFilePath(bundleId, dumpId));
+		public bool IsPrimaryDumpAvailable(DumpIdentifier id) {
+			return File.Exists(GetDumpFilePath(id));
 		}
 	}
 }

--- a/src/SuperDumpService/Services/DumpRepository.cs
+++ b/src/SuperDumpService/Services/DumpRepository.cs
@@ -16,12 +16,12 @@ namespace SuperDumpService.Services {
 	public class DumpRepository {
 		private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, DumpMetainfo>> dumps = new ConcurrentDictionary<string, ConcurrentDictionary<string, DumpMetainfo>>();
 		private readonly ConcurrentDictionary<DumpIdentifier, DumpMiniInfo> miniInfosLazyCache = new ConcurrentDictionary<DumpIdentifier, DumpMiniInfo>();
-		private readonly DumpStorageFilebased storage;
+		private readonly IDumpStorage storage;
 		private readonly PathHelper pathHelper;
 
 		public bool IsPopulated { get; private set; }
 
-		public DumpRepository(DumpStorageFilebased storage, PathHelper pathHelper) {
+		public DumpRepository(IDumpStorage storage, PathHelper pathHelper) {
 			this.storage = storage;
 			this.pathHelper = pathHelper;
 		}

--- a/src/SuperDumpService/Services/DumpRetentionService.cs
+++ b/src/SuperDumpService/Services/DumpRetentionService.cs
@@ -46,7 +46,7 @@ namespace SuperDumpService.Services {
 		/// There is no exception handling because exceptions are visible in Hangfire as opposed to log messages.
 		/// </summary>
 		private void RemoveOldDumps(DumpMetainfo dump) {
-			string dumpDirectory = pathHelper.GetDumpDirectory(dump.BundleId, dump.DumpId);
+			string dumpDirectory = pathHelper.GetDumpDirectory(dump.Id);
 			if (!Directory.Exists(dumpDirectory)) {
 				return;
 			}

--- a/src/SuperDumpService/Services/DumpStorageFilebased.cs
+++ b/src/SuperDumpService/Services/DumpStorageFilebased.cs
@@ -28,10 +28,11 @@ namespace SuperDumpService.Services {
 			var list = new List<DumpMetainfo>();
 			foreach (var dir in Directory.EnumerateDirectories(pathHelper.GetBundleDirectory(bundleId))) {
 				var dumpId = new DirectoryInfo(dir).Name;
-				var metainfoFilename = pathHelper.GetDumpMetadataPath(bundleId, dumpId);
+				var id = new DumpIdentifier(bundleId, dumpId);
+				var metainfoFilename = pathHelper.GetDumpMetadataPath(id);
 				if (!File.Exists(metainfoFilename)) {
 					// backwards compatibility, when Metadata files did not exist. read full json, then store metadata file
-					await CreateMetainfoForCompat(bundleId, dumpId);
+					await CreateMetainfoForCompat(id);
 				}
 				list.Add(ReadMetainfoFile(metainfoFilename));
 			}
@@ -42,8 +43,8 @@ namespace SuperDumpService.Services {
 			return JsonConvert.DeserializeObject<DumpMetainfo>(File.ReadAllText(filename));
 		}
 
-		private DumpMetainfo ReadMetainfoFile(string bundleId, string dumpId) {
-			return ReadMetainfoFile(pathHelper.GetDumpMetadataPath(bundleId, dumpId));
+		private DumpMetainfo ReadMetainfoFile(DumpIdentifier id) {
+			return ReadMetainfoFile(pathHelper.GetDumpMetadataPath(id));
 		}
 
 		private void WriteMetainfoFile(DumpMetainfo metaInfo, string filename) {
@@ -58,12 +59,12 @@ namespace SuperDumpService.Services {
 			return JsonConvert.DeserializeObject<DumpMiniInfo>(await File.ReadAllTextAsync(pathHelper.GetDumpMiniInfoPath(id)));
 		}
 
-		private async Task CreateMetainfoForCompat(string bundleId, string dumpId) {
+		private async Task CreateMetainfoForCompat(DumpIdentifier id) {
 			var metainfo = new DumpMetainfo() {
-				BundleId = bundleId,
-				DumpId = dumpId
+				BundleId = id.BundleId,
+				DumpId = id.DumpId
 			};
-			var result = await ReadResults(bundleId, dumpId);
+			var result = await ReadResults(id);
 			if (result != null) {
 				metainfo.Status = DumpStatus.Finished;
 				metainfo.DumpFileName = result.AnalysisInfo.Path?.Replace(pathHelper.GetUploadsDir(), ""); // AnalysisInfo.FileName used to store full file names. e.g. "C:\superdump\uploads\myzipfilename\subdir\dump.dmp". lets only keep "myzipfilename\subdir\dump.dmp"
@@ -72,23 +73,23 @@ namespace SuperDumpService.Services {
 				metainfo.Status = DumpStatus.Failed;
 			}
 
-			WriteMetainfoFile(metainfo, pathHelper.GetDumpMetadataPath(bundleId, dumpId));
+			WriteMetainfoFile(metainfo, pathHelper.GetDumpMetadataPath(id));
 		}
 
-		public async Task<SDResult> ReadResults(string bundleId, string dumpId) {
+		public async Task<SDResult> ReadResults(DumpIdentifier id) {
 			try {
-				return await ReadResultsAndThrow(bundleId, dumpId);
+				return await ReadResultsAndThrow(id);
 			} catch (Exception e) {
 				Console.Error.WriteLine(e.Message);
 				return null;
 			}
 		}
 
-		public async Task<SDResult> ReadResultsAndThrow(string bundleId, string dumpId) {
-			var filename = pathHelper.GetJsonPath(bundleId, dumpId);
+		public async Task<SDResult> ReadResultsAndThrow(DumpIdentifier id) {
+			var filename = pathHelper.GetJsonPath(id);
 			if (!File.Exists(filename)) {
 				// fallback for older dumps
-				filename = pathHelper.GetJsonPathFallback(bundleId, dumpId);
+				filename = pathHelper.GetJsonPathFallback(id);
 				if (!File.Exists(filename)) return null;
 			}
 			try {
@@ -102,7 +103,7 @@ namespace SuperDumpService.Services {
 		}
 
 		public void WriteResult(DumpIdentifier id, SDResult result) {
-			string filename = pathHelper.GetJsonPath(id.BundleId, id.DumpId);
+			string filename = pathHelper.GetJsonPath(id);
 			try {
 				result.WriteResultToJSONFile(filename);
 			} catch (Exception e) {
@@ -111,8 +112,8 @@ namespace SuperDumpService.Services {
 			}
 		}
 
-		public string GetDumpFilePath(string bundleId, string dumpId) {
-			var filename = GetSDFileInfos(bundleId, dumpId).FirstOrDefault(x => x.FileEntry.Type == SDFileType.PrimaryDump)?.FileInfo;
+		public string GetDumpFilePath(DumpIdentifier id) {
+			var filename = GetSDFileInfos(id).FirstOrDefault(x => x.FileEntry.Type == SDFileType.PrimaryDump)?.FileInfo;
 			if (filename == null) return null;
 			if (!filename.Exists) return null;
 			return filename.FullName;
@@ -121,16 +122,16 @@ namespace SuperDumpService.Services {
 		/// <summary>
 		/// actually copies a file into the dumpdirectory
 		/// </summary>
-		public async Task<FileInfo> AddFileCopy(string bundleId, string dumpId, FileInfo sourcePath) {
-			return await Utility.CopyFile(sourcePath, new FileInfo(Path.Combine(pathHelper.GetDumpDirectory(bundleId, dumpId), sourcePath.Name)));
+		public async Task<FileInfo> AddFileCopy(DumpIdentifier id, FileInfo sourcePath) {
+			return await Utility.CopyFile(sourcePath, new FileInfo(Path.Combine(pathHelper.GetDumpDirectory(id), sourcePath.Name)));
 		}
 
-		public void DeleteDumpFile(string bundleId, string dumpId) {
-			File.Delete(GetDumpFilePath(bundleId, dumpId));
+		public void DeleteDumpFile(DumpIdentifier id) {
+			File.Delete(GetDumpFilePath(id));
 		}
 
-		public void Create(string bundleId, string dumpId) {
-			string dir = pathHelper.GetDumpDirectory(bundleId, dumpId);
+		public void Create(DumpIdentifier id) {
+			string dir = pathHelper.GetDumpDirectory(id);
 			if (Directory.Exists(dir)) {
 				throw new DirectoryAlreadyExistsException("Cannot create '{dir}'. It already exists.");
 			}
@@ -142,13 +143,13 @@ namespace SuperDumpService.Services {
 		}
 
 		public void Store(DumpMetainfo dumpInfo) {
-			WriteMetainfoFile(dumpInfo, pathHelper.GetDumpMetadataPath(dumpInfo.BundleId, dumpInfo.DumpId));
+			WriteMetainfoFile(dumpInfo, pathHelper.GetDumpMetadataPath(dumpInfo.Id));
 		}
 
-		public IEnumerable<SDFileInfo> GetSDFileInfos(string bundleId, string dumpId) {
-			foreach (var filePath in Directory.EnumerateFiles(pathHelper.GetDumpDirectory(bundleId, dumpId))) {
+		public IEnumerable<SDFileInfo> GetSDFileInfos(DumpIdentifier id) {
+			foreach (var filePath in Directory.EnumerateFiles(pathHelper.GetDumpDirectory(id))) {
 				// in case the requested file has a "special" entry in FileEntry list, add that information
-				var dumpInfo = ReadMetainfoFile(bundleId, dumpId);
+				var dumpInfo = ReadMetainfoFile(id);
 				FileInfo fileInfo = new FileInfo(filePath);
 				SDFileEntry fileEntry = GetSDFileEntry(dumpInfo, fileInfo);
 				
@@ -170,11 +171,11 @@ namespace SuperDumpService.Services {
 			fileEntry = new SDFileEntry() {
 				FileName = fileInfo.Name
 			};
-			if (Path.GetFileName(pathHelper.GetJsonPath(dumpInfo.BundleId, dumpInfo.DumpId)) == fileInfo.Name) {
+			if (Path.GetFileName(pathHelper.GetJsonPath(dumpInfo.Id)) == fileInfo.Name) {
 				fileEntry.Type = SDFileType.SuperDumpMetaData;
 				return fileEntry;
 			}
-			if (Path.GetFileName(pathHelper.GetDumpMetadataPath(dumpInfo.BundleId, dumpInfo.DumpId)) == fileInfo.Name) {
+			if (Path.GetFileName(pathHelper.GetDumpMetadataPath(dumpInfo.Id)) == fileInfo.Name) {
 				fileEntry.Type = SDFileType.SuperDumpMetaData;
 				return fileEntry;
 			}
@@ -182,7 +183,7 @@ namespace SuperDumpService.Services {
 				fileEntry.Type = SDFileType.SuperDumpMetaData;
 				return fileEntry;
 			}
-			if (Path.GetFileName(pathHelper.GetRelationshipsPath(dumpInfo.BundleId, dumpInfo.DumpId)) == fileInfo.Name) {
+			if (Path.GetFileName(pathHelper.GetRelationshipsPath(dumpInfo.Id)) == fileInfo.Name) {
 				fileEntry.Type = SDFileType.SuperDumpMetaData;
 				return fileEntry;
 			}
@@ -219,17 +220,17 @@ namespace SuperDumpService.Services {
 			return fileEntry;
 		}
 
-		public FileInfo GetFile(string bundleId, string dumpId, string filename) {
+		public FileInfo GetFile(DumpIdentifier id, string filename) {
 			// make sure filename is not some relative ".."
 			if (filename.Contains("..")) throw new UnauthorizedAccessException();
 
-			string dir = pathHelper.GetDumpDirectory(bundleId, dumpId);
+			string dir = pathHelper.GetDumpDirectory(id);
 			var file = new FileInfo(Path.Combine(dir, filename));
 
 			// make sure file really is inside of the dumps-directory
 			if (!file.FullName.ToLower().Contains(dir.ToLower())) throw new UnauthorizedAccessException();
 
-			var dumpInfo = ReadMetainfoFile(bundleId, dumpId);
+			var dumpInfo = ReadMetainfoFile(id);
 			SDFileEntry fileEntry = GetSDFileEntry(dumpInfo, file);
 
 			if (fileEntry.Type == SDFileType.PrimaryDump && !settings.Value.DumpDownloadable) {

--- a/src/SuperDumpService/Services/DumpStorageFilebased.cs
+++ b/src/SuperDumpService/Services/DumpStorageFilebased.cs
@@ -15,7 +15,7 @@ namespace SuperDumpService.Services {
 	/// for writing and reading of dumps only
 	/// this implementation uses simple filebased storage
 	/// </summary>
-	public class DumpStorageFilebased {
+	public class DumpStorageFilebased : IDumpStorage {
 		private readonly PathHelper pathHelper;
 		private readonly IOptions<SuperDumpSettings> settings;
 
@@ -50,11 +50,11 @@ namespace SuperDumpService.Services {
 			File.WriteAllText(filename, JsonConvert.SerializeObject(metaInfo, Formatting.Indented));
 		}
 
-		internal bool MiniInfoExists(DumpIdentifier id) {
+		public bool MiniInfoExists(DumpIdentifier id) {
 			return File.Exists(pathHelper.GetDumpMiniInfoPath(id));
 		}
 
-		internal async Task<DumpMiniInfo> ReadMiniInfo(DumpIdentifier id) {
+		public async Task<DumpMiniInfo> ReadMiniInfo(DumpIdentifier id) {
 			return JsonConvert.DeserializeObject<DumpMiniInfo>(await File.ReadAllTextAsync(pathHelper.GetDumpMiniInfoPath(id)));
 		}
 
@@ -121,15 +121,15 @@ namespace SuperDumpService.Services {
 		/// <summary>
 		/// actually copies a file into the dumpdirectory
 		/// </summary>
-		internal async Task<FileInfo> AddFileCopy(string bundleId, string dumpId, FileInfo sourcePath) {
+		public async Task<FileInfo> AddFileCopy(string bundleId, string dumpId, FileInfo sourcePath) {
 			return await Utility.CopyFile(sourcePath, new FileInfo(Path.Combine(pathHelper.GetDumpDirectory(bundleId, dumpId), sourcePath.Name)));
 		}
 
-		internal void DeleteDumpFile(string bundleId, string dumpId) {
+		public void DeleteDumpFile(string bundleId, string dumpId) {
 			File.Delete(GetDumpFilePath(bundleId, dumpId));
 		}
 
-		internal void Create(string bundleId, string dumpId) {
+		public void Create(string bundleId, string dumpId) {
 			string dir = pathHelper.GetDumpDirectory(bundleId, dumpId);
 			if (Directory.Exists(dir)) {
 				throw new DirectoryAlreadyExistsException("Cannot create '{dir}'. It already exists.");
@@ -137,15 +137,15 @@ namespace SuperDumpService.Services {
 			Directory.CreateDirectory(dir);
 		}
 
-		internal async Task StoreMiniInfo(DumpIdentifier id, DumpMiniInfo miniInfo) {
+		public async Task StoreMiniInfo(DumpIdentifier id, DumpMiniInfo miniInfo) {
 			await File.WriteAllTextAsync(pathHelper.GetDumpMiniInfoPath(id), JsonConvert.SerializeObject(miniInfo, Formatting.None));
 		}
 
-		internal void Store(DumpMetainfo dumpInfo) {
+		public void Store(DumpMetainfo dumpInfo) {
 			WriteMetainfoFile(dumpInfo, pathHelper.GetDumpMetadataPath(dumpInfo.BundleId, dumpInfo.DumpId));
 		}
 
-		internal IEnumerable<SDFileInfo> GetSDFileInfos(string bundleId, string dumpId) {
+		public IEnumerable<SDFileInfo> GetSDFileInfos(string bundleId, string dumpId) {
 			foreach (var filePath in Directory.EnumerateFiles(pathHelper.GetDumpDirectory(bundleId, dumpId))) {
 				// in case the requested file has a "special" entry in FileEntry list, add that information
 				var dumpInfo = ReadMetainfoFile(bundleId, dumpId);

--- a/src/SuperDumpService/Services/ElasticSDResult.cs
+++ b/src/SuperDumpService/Services/ElasticSDResult.cs
@@ -122,7 +122,7 @@ namespace SuperDumpService.Services {
 
 		private static long ComputeDumpFileSizeKb(BundleMetainfo bundleInfo, DumpMetainfo dumpInfo, PathHelper pathHelper) {
 			long dumpSize = -1;
-			string dumpDirectory = pathHelper.GetDumpDirectory(bundleInfo.BundleId, dumpInfo.DumpId);
+			string dumpDirectory = pathHelper.GetDumpDirectory(dumpInfo.Id);
 			if (!Directory.Exists(dumpDirectory)) {
 				return -1;
 			}

--- a/src/SuperDumpService/Services/ElasticSearchService.cs
+++ b/src/SuperDumpService/Services/ElasticSearchService.cs
@@ -95,7 +95,7 @@ namespace SuperDumpService.Services {
 					if (documentIds.Contains(bundle.BundleId + "/" + dump.DumpId)) {
 						continue;
 					}
-					SDResult result = await dumpRepo.GetResult(bundle.BundleId, dump.DumpId);
+					SDResult result = await dumpRepo.GetResult(dump.Id);
 					if (result != null) {
 						bool success = await PushResultAsync(result, bundle, dump);
 						if (!success && nErrorsLogged < 20) {

--- a/src/SuperDumpService/Services/IDumpStorage.cs
+++ b/src/SuperDumpService/Services/IDumpStorage.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using SuperDump.Models;
+using SuperDumpService.Models;
+
+namespace SuperDumpService.Services {
+	public interface IDumpStorage {
+		Task<FileInfo> AddFileCopy(string bundleId, string dumpId, FileInfo sourcePath);
+		void Create(string bundleId, string dumpId);
+		void DeleteDumpFile(string bundleId, string dumpId);
+		string GetDumpFilePath(string bundleId, string dumpId);
+		FileInfo GetFile(string bundleId, string dumpId, string filename);
+		IEnumerable<SDFileInfo> GetSDFileInfos(string bundleId, string dumpId);
+		bool MiniInfoExists(DumpIdentifier id);
+		Task<IEnumerable<DumpMetainfo>> ReadDumpMetainfoForBundle(string bundleId);
+		Task<DumpMiniInfo> ReadMiniInfo(DumpIdentifier id);
+		Task<SDResult> ReadResults(string bundleId, string dumpId);
+		Task<SDResult> ReadResultsAndThrow(string bundleId, string dumpId);
+		void Store(DumpMetainfo dumpInfo);
+		Task StoreMiniInfo(DumpIdentifier id, DumpMiniInfo miniInfo);
+		void WriteResult(DumpIdentifier id, SDResult result);
+	}
+}

--- a/src/SuperDumpService/Services/IDumpStorage.cs
+++ b/src/SuperDumpService/Services/IDumpStorage.cs
@@ -6,17 +6,17 @@ using SuperDumpService.Models;
 
 namespace SuperDumpService.Services {
 	public interface IDumpStorage {
-		Task<FileInfo> AddFileCopy(string bundleId, string dumpId, FileInfo sourcePath);
-		void Create(string bundleId, string dumpId);
-		void DeleteDumpFile(string bundleId, string dumpId);
-		string GetDumpFilePath(string bundleId, string dumpId);
-		FileInfo GetFile(string bundleId, string dumpId, string filename);
-		IEnumerable<SDFileInfo> GetSDFileInfos(string bundleId, string dumpId);
+		Task<FileInfo> AddFileCopy(DumpIdentifier id, FileInfo sourcePath);
+		void Create(DumpIdentifier id);
+		void DeleteDumpFile(DumpIdentifier id);
+		string GetDumpFilePath(DumpIdentifier id);
+		FileInfo GetFile(DumpIdentifier id, string filename);
+		IEnumerable<SDFileInfo> GetSDFileInfos(DumpIdentifier id);
 		bool MiniInfoExists(DumpIdentifier id);
 		Task<IEnumerable<DumpMetainfo>> ReadDumpMetainfoForBundle(string bundleId);
 		Task<DumpMiniInfo> ReadMiniInfo(DumpIdentifier id);
-		Task<SDResult> ReadResults(string bundleId, string dumpId);
-		Task<SDResult> ReadResultsAndThrow(string bundleId, string dumpId);
+		Task<SDResult> ReadResults(DumpIdentifier id);
+		Task<SDResult> ReadResultsAndThrow(DumpIdentifier id);
 		void Store(DumpMetainfo dumpInfo);
 		Task StoreMiniInfo(DumpIdentifier id, DumpMiniInfo miniInfo);
 		void WriteResult(DumpIdentifier id, SDResult result);

--- a/src/SuperDumpService/Services/IRelationshipStorage.cs
+++ b/src/SuperDumpService/Services/IRelationshipStorage.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using SuperDumpService.Models;
+
+namespace SuperDumpService.Services {
+	public interface IRelationshipStorage {
+		Task<IDictionary<DumpIdentifier, double>> ReadRelationships(DumpIdentifier dumpId);
+		Task StoreRelationships(DumpIdentifier dumpId, IDictionary<DumpIdentifier, double> relationships);
+		void Wipe(DumpIdentifier dumpId);
+	}
+}

--- a/src/SuperDumpService/Services/RelationshipRepository.cs
+++ b/src/SuperDumpService/Services/RelationshipRepository.cs
@@ -15,12 +15,12 @@ namespace SuperDumpService.Services {
 
 		// stores relationships bi-directional. both directions should stay in sync
 		private readonly IDictionary<DumpIdentifier, IDictionary<DumpIdentifier, double>> relationShips = new Dictionary<DumpIdentifier, IDictionary<DumpIdentifier, double>>();
-		private readonly RelationshipStorageFilebased relationshipStorage;
+		private readonly IRelationshipStorage relationshipStorage;
 		private readonly DumpRepository dumpRepo;
 		private readonly IOptions<SuperDumpSettings> settings;
 		public bool IsPopulated { get; private set; } = false;
 
-		public RelationshipRepository(RelationshipStorageFilebased relationshipStorage, DumpRepository dumpRepo, IOptions<SuperDumpSettings> settings) {
+		public RelationshipRepository(IRelationshipStorage relationshipStorage, DumpRepository dumpRepo, IOptions<SuperDumpSettings> settings) {
 			this.relationshipStorage = relationshipStorage;
 			this.dumpRepo = dumpRepo;
 			this.settings = settings;

--- a/src/SuperDumpService/Services/RelationshipStorageFilebased.cs
+++ b/src/SuperDumpService/Services/RelationshipStorageFilebased.cs
@@ -22,19 +22,19 @@ namespace SuperDumpService.Services {
 			this.pathHelper = pathHelper;
 		}
 
-		public async Task StoreRelationships(DumpIdentifier dumpId, IDictionary<DumpIdentifier, double> relationships) {
+		public async Task StoreRelationships(DumpIdentifier id, IDictionary<DumpIdentifier, double> relationships) {
 			List<KeyValuePair<DumpIdentifier, double>> data = relationships.OrderByDescending(x => Math.Round(x.Value, 3)).ToList(); // use a list, otherwise complex key (DumpIdentifier) is problematic
-			await File.WriteAllTextAsync(pathHelper.GetRelationshipsPath(dumpId.BundleId, dumpId.DumpId), JsonConvert.SerializeObject(data));
+			await File.WriteAllTextAsync(pathHelper.GetRelationshipsPath(id), JsonConvert.SerializeObject(data));
 		}
 
-		public async Task<IDictionary<DumpIdentifier, double>> ReadRelationships(DumpIdentifier dumpId) {
-			string text = await File.ReadAllTextAsync(pathHelper.GetRelationshipsPath(dumpId.BundleId, dumpId.DumpId));
+		public async Task<IDictionary<DumpIdentifier, double>> ReadRelationships(DumpIdentifier id) {
+			string text = await File.ReadAllTextAsync(pathHelper.GetRelationshipsPath(id));
 			var data = JsonConvert.DeserializeObject<List<KeyValuePair<DumpIdentifier, double>>>(text);
 			return data.ToDictionary(x => x.Key, y => y.Value);
 		}
 
-		public void Wipe(DumpIdentifier dumpId) {
-			File.Delete(pathHelper.GetRelationshipsPath(dumpId.BundleId, dumpId.DumpId));
+		public void Wipe(DumpIdentifier id) {
+			File.Delete(pathHelper.GetRelationshipsPath(id));
 		}
 	}
 }

--- a/src/SuperDumpService/Services/RelationshipStorageFilebased.cs
+++ b/src/SuperDumpService/Services/RelationshipStorageFilebased.cs
@@ -15,13 +15,11 @@ namespace SuperDumpService.Services {
 	/// for writing and reading of relationship information
 	/// this implementation uses simple filebased storage
 	/// </summary>
-	public class RelationshipStorageFilebased {
+	public class RelationshipStorageFilebased : IRelationshipStorage {
 		private readonly PathHelper pathHelper;
-		private readonly IOptions<SuperDumpSettings> settings;
 
-		public RelationshipStorageFilebased(PathHelper pathHelper, IOptions<SuperDumpSettings> settings) {
+		public RelationshipStorageFilebased(PathHelper pathHelper) {
 			this.pathHelper = pathHelper;
-			this.settings = settings;
 		}
 
 		public async Task StoreRelationships(DumpIdentifier dumpId, IDictionary<DumpIdentifier, double> relationships) {

--- a/src/SuperDumpService/Services/SlackNotificationService.cs
+++ b/src/SuperDumpService/Services/SlackNotificationService.cs
@@ -42,7 +42,7 @@ namespace SuperDumpService.Services {
 		public async Task<string> GetMessage(DumpMetainfo dumpInfo) {
 			var model = new SlackMessageViewModel();
 
-			var res = await dumpRepo.GetResult(dumpInfo.BundleId, dumpInfo.DumpId);
+			var res = await dumpRepo.GetResult(dumpInfo.Id);
 			
 			var engine = new EngineFactory().ForEmbeddedResources(typeof(SlackMessageViewModel));
 			model.TopProperties.Add(dumpInfo.DumpType == DumpType.WindowsDump ? "Windows" : "Linux");

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -51,7 +51,11 @@ namespace SuperDumpService {
 			services.AddOptions();
 			services.Configure<SuperDumpSettings>(config.GetSection(nameof(SuperDumpSettings)));
 
-			var pathHelper = new PathHelper(config.GetSection(nameof(SuperDumpSettings)));
+			var pathHelper = new PathHelper(
+				configurationSection.GetValue<string>(nameof(SuperDumpSettings.DumpsDir)) ?? Path.Combine(Directory.GetCurrentDirectory(), @"../../data/dumps/"),
+				configurationSection.GetValue<string>(nameof(SuperDumpSettings.UploadDir)) ?? Path.Combine(Directory.GetCurrentDirectory(), @"../../data/uploads/"),
+				configurationSection.GetValue<string>(nameof(SuperDumpSettings.HangfireLocalDbDir)) ?? Path.Combine(Directory.GetCurrentDirectory(), @"../../data/hangfire/")
+			);
 			services.AddSingleton(pathHelper);
 
 			var superDumpSettings = new SuperDumpSettings();
@@ -134,7 +138,7 @@ namespace SuperDumpService {
 			services.AddSingleton<BundleRepository>();
 			services.AddSingleton<BundleStorageFilebased>();
 			services.AddSingleton<DumpRepository>();
-			services.AddSingleton<DumpStorageFilebased>();
+			services.AddSingleton<IDumpStorage, DumpStorageFilebased>();
 			services.AddSingleton<AnalysisService>();
 			services.AddSingleton<DownloadService>();
 			services.AddSingleton<SymStoreService>();
@@ -145,7 +149,7 @@ namespace SuperDumpService {
 			services.AddSingleton<DumpRetentionService>();
 			services.AddSingleton<SimilarityService>();
 			services.AddSingleton<RelationshipRepository>();
-			services.AddSingleton<RelationshipStorageFilebased>();
+			services.AddSingleton<IRelationshipStorage, RelationshipStorageFilebased>();
 			services.AddSingleton<IdenticalDumpStorageFilebased>();
 			services.AddSingleton<IdenticalDumpRepository>();
 			services.AddSingleton<JiraApiService>();

--- a/src/SuperDumpService/TagHelpers/InteractiveLinkTagHelper.cs
+++ b/src/SuperDumpService/TagHelpers/InteractiveLinkTagHelper.cs
@@ -12,16 +12,14 @@ namespace SuperDumpService.TagHelpers {
 		public ReportViewModel Model { get; set; }
 		public string InteractiveGdbHost { get; set; }
 		public DumpType Type { get; set; }
-		public string DumpId { get; set; }
-		public string BundleId { get; set; }
+		public DumpIdentifier Id { get; set; }
 		public string Executable { get; set; }
 		public string Command { get; set; }
 
 		public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output) {
 			InteractiveGdbHost = Model.InteractiveGdbHost;
 			Type = Model.DumpType;
-			DumpId = Model.DumpId;
-			BundleId = Model.BundleId;
+			Id = Model.Id;
 			Executable = (Model.Result?.SystemContext as SDCDSystemContext)?.FileName;
 	
 	string url;
@@ -33,12 +31,12 @@ namespace SuperDumpService.TagHelpers {
 					return base.ProcessAsync(context, output);
 				}
 
-				url = $"{InteractiveGdbHost}/?arg={BundleId}&arg={DumpId}&arg={Executable}";
+				url = $"{InteractiveGdbHost}/?arg={Id.BundleId}&arg={Id.DumpId}&arg={Executable}";
 				if (!string.IsNullOrEmpty(Command)) {
 					url += $"&arg=\"{Command}\"";
 				}
 			} else {
-				url = $"Interactive?bundleId={BundleId}&dumpId={DumpId}";
+				url = $"Interactive?bundleId={Id.BundleId}&dumpId={Id.DumpId}";
 				if(!string.IsNullOrEmpty(Command)) {
 					url += $"&cmd={Command}";
 				}

--- a/src/SuperDumpService/ViewModels/FileViewModel.cs
+++ b/src/SuperDumpService/ViewModels/FileViewModel.cs
@@ -2,13 +2,11 @@
 
 namespace SuperDumpService.ViewModels {
 	public class FileViewModel {
-		public string BundleId { get; private set; }
-		public string DumpId { get; private set; }
+		public DumpIdentifier Id { get; private set; }
 		public SDFileInfo File { get; private set; }
 
-		public FileViewModel(string bundleId, string dumpId, SDFileInfo file) {
-			this.BundleId = bundleId;
-			this.DumpId = dumpId;
+		public FileViewModel(DumpIdentifier id, SDFileInfo file) {
+			this.Id = id;
 			this.File = file;
 		}
 	}

--- a/src/SuperDumpService/ViewModels/InteractiveViewModel.cs
+++ b/src/SuperDumpService/ViewModels/InteractiveViewModel.cs
@@ -4,8 +4,7 @@ using System.Collections.Generic;
 
 namespace SuperDumpService.ViewModels {
 	public class InteractiveViewModel {
-		public string BundleId { get; set; }
-		public string DumpId { get; set; }
+		public DumpIdentifier Id { get; set; }
 		public DumpMetainfo DumpInfo { get; set; }
 		public string Command { get; set; }
 	}

--- a/src/SuperDumpService/ViewModels/ReportViewModel.cs
+++ b/src/SuperDumpService/ViewModels/ReportViewModel.cs
@@ -7,9 +7,7 @@ using SuperDumpService.Services;
 
 namespace SuperDumpService.ViewModels {
 	public class ReportViewModel {
-		public DumpIdentifier DumpIdentifier => new DumpIdentifier(BundleId, DumpId);
-		public string BundleId { get; set; }
-		public string DumpId { get; set; }
+		public DumpIdentifier Id { get; set; }
 		public string BundleFileName { get; set; }
 		public string DumpFileName { get; set; }
 		public DateTime TimeStamp { get; set; }
@@ -34,9 +32,8 @@ namespace SuperDumpService.ViewModels {
 		public bool IsRelationshipsPopulated { get; set; }
 		public bool IsJiraIssuesPopulated { get; set; }
 
-		public ReportViewModel(string bundleId, string dumpId) {
-			this.BundleId = bundleId;
-			this.DumpId = dumpId;
+		public ReportViewModel(DumpIdentifier id) {
+			this.Id = id;
 		}
 
 		private static readonly string[] sizeSuffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };

--- a/src/SuperDumpService/Views/Home/Interactive.cshtml
+++ b/src/SuperDumpService/Views/Home/Interactive.cshtml
@@ -26,7 +26,7 @@
 	<div class="container-webterm" style="padding-top: 50px;">
 		<div style="display:inline-block; float: left; padding: 8px;">
 			Interactive debug session for <strong>@Model.DumpInfo.DumpFileName</strong>.
-			<a asp-controller="Home" asp-action="Report" asp-route-bundleId="@Model.BundleId" asp-route-dumpId="@Model.DumpId">Back to Report</a>
+			<a asp-controller="Home" asp-action="Report" asp-route-bundleId="@Model.Id.BundleId" asp-route-dumpId="@Model.Id.DumpId">Back to Report</a>
 		</div>
 		<div style="display:inline-block; float: right; padding: 8px;">
 			<a href="http://windbg.info/doc/1-common-cmds.html">WinDbg Cheat Sheet</a>

--- a/src/SuperDumpService/Views/Home/Report.cshtml
+++ b/src/SuperDumpService/Views/Home/Report.cshtml
@@ -18,7 +18,7 @@
 
 } else {
 	<div class="wrapper">
-		<h2>Dump Id: @Model.DumpId</h2>
+		<h2>Dump Id: @Model.Id.DumpId</h2>
 		@if (!Model.IsRelationshipsPopulated) {
 			<div>
 				<span class="glyphicon glyphicon-exclamation-sign"></span> <strong>Similarity repository</strong> is being populated right now. Similarities might not be complete yet.
@@ -36,8 +36,8 @@
 				@if (Model.IsDumpAvailable && AuthorizationHelper.CheckPolicy(User, LdapCookieAuthenticationExtension.UserPolicy)) {
 					@using (Html.BeginForm("Rerun", "Home")) {
 						<div class="form-group text-right">
-							<input type="hidden" name="bundleId" value="@Model.BundleId" />
-							<input type="hidden" name="dumpId" value="@Model.DumpId" />
+							<input type="hidden" name="bundleId" value="@Model.Id.BundleId" />
+							<input type="hidden" name="dumpId" value="@Model.Id.DumpId" />
 							<input type="submit" value="Rerun Analysis" class="btn btn-danger" />
 						</div>
 					}
@@ -76,7 +76,7 @@
 										@foreach (var rel in dupls.OrderByDescending(x => x.Value + (Model.UseJiraIntegration && Model.SimilarDumpIssues.ContainsKey(x.Key.BundleId) ? 100 : 0))) {
 											<li class="list-group-item">
 												<div class="small">(@rel.Key.Created)</div>
-												<a asp-controller="Similarity" asp-action="CompareDumps" asp-route-bundleId1="@Model.BundleId" asp-route-dumpId1="@Model.DumpId" asp-route-bundleId2="@rel.Key.BundleId" asp-route-dumpId2="@rel.Key.DumpId">
+												<a asp-controller="Similarity" asp-action="CompareDumps" asp-route-bundleId1="@Model.Id.BundleId" asp-route-dumpId1="@Model.Id.DumpId" asp-route-bundleId2="@rel.Key.Id.BundleId" asp-route-dumpId2="@rel.Key.Id.DumpId">
 													<span class="font-weight-bold text-success">@Math.Round(rel.Value * 100.0, 0)&#37;</span>
 												</a>
 												<a asp-controller="Home" asp-action="Report" asp-route-bundleId="@rel.Key.BundleId" asp-route-dumpId="@rel.Key.DumpId">@System.IO.Path.GetFileName(rel.Key.DumpFileName)</a>
@@ -137,7 +137,7 @@
 									<ul class="flat">
 										@foreach (SDFileInfo file in Model.Files.Where(x => Utility.GetEnumDescription(x.FileEntry.Type) == filetype).OrderBy(x => x.FileEntry.FileName)) {
 											<li>
-												@{Html.RenderPartial("_File", new FileViewModel(Model.BundleId, Model.DumpId, file));}
+												@{Html.RenderPartial("_File", new FileViewModel(Model.Id, file));}
 											</li>
 										}
 									</ul>

--- a/src/SuperDumpService/Views/Home/Rerun.cshtml
+++ b/src/SuperDumpService/Views/Home/Rerun.cshtml
@@ -6,6 +6,6 @@
 <p>You'll be redirected to the report in 3 seconds...</p>
 <script>
 	setTimeout(function () {
-		window.location.replace("/Home/Report?bundleId=@Model.BundleId&dumpId=@Model.DumpId");
+		window.location.replace("/Home/Report?bundleId=@Model.Id.BundleId&dumpId=@Model.Id.DumpId");
 	}, 3000);
 </script>

--- a/src/SuperDumpService/Views/Home/_File.cshtml
+++ b/src/SuperDumpService/Views/Home/_File.cshtml
@@ -9,7 +9,7 @@
 (AuthorizationHelper.CheckPolicy(User, LdapCookieAuthenticationExtension.UserPolicy) ||
 Settings.Value.LdapAuthenticationSettings.ViewerDownloadableFiles.Any(f => f == Model.File.FileInfo.Name) &&
 AuthorizationHelper.CheckPolicy(User, LdapCookieAuthenticationExtension.ViewerPolicy))) {
-<a asp-controller="Home" asp-action="DownloadFile" asp-route-bundleId="@Model.BundleId" asp-route-dumpId="@Model.DumpId" asp-route-filename="@Model.File.FileInfo.Name">
+<a asp-controller="Home" asp-action="DownloadFile" asp-route-bundleId="@Model.Id.BundleId" asp-route-dumpId="@Model.Id.DumpId" asp-route-filename="@Model.File.FileInfo.Name">
 	@Model.File.FileInfo.Name</a>
 <span class="filesize">(@SuperDumpService.Helpers.Utility.FormattedBytes(Model.File.SizeInBytes, 0))</span>
 } else {

--- a/src/SuperDumpService/Views/Home/_Memory.cshtml
+++ b/src/SuperDumpService/Views/Home/_Memory.cshtml
@@ -38,7 +38,7 @@
 									data: {
 										labels: types,
 										datasets: [{
-											label: '@Model.DumpId',
+											label: '@Model.Id.DumpId',
 											data: sizes,
 											backgroundColor: [
 												'rgba(255, 99, 132, 0.4)',


### PR DESCRIPTION

 * Use DumpIdentifier in all APIs. This implifies a lot of code.
 * Reduce dependencies. Created interfaces for a few classes to make abstraction in tests easier.