### PR TITLE
reduce memory consumption

### DIFF
--- a/src/SuperDumpService.Benchmark/Benchmarks/MiniInfoBenchmarks.cs
+++ b/src/SuperDumpService.Benchmark/Benchmarks/MiniInfoBenchmarks.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Options;
+using SuperDump.Models;
+using SuperDumpService.Benchmarks.Fakes;
+using SuperDumpService.Helpers;
+using SuperDumpService.Models;
+using SuperDumpService.Services;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.IO;
+
+namespace SuperDumpService.Benchmark.Benchmarks {
+	/// <summary>
+	/// Test memory consumption of MiniInfo. It's important to keep it minimal.
+	/// 
+	/// before changes: 6.1kb
+	/// </summary>
+	[ShortRunJob]
+	[MemoryDiagnoser]
+	public class MiniInfoBenchmarks {
+		private SDResult sdresult;
+		private List<DumpMiniInfo> mininfos = new List<DumpMiniInfo>();
+
+		public MiniInfoBenchmarks() { }
+
+		[GlobalSetup]
+		public void GlobalSetup() {
+			sdresult = CreateSDResult();
+		}
+
+		private SDResult CreateSDResult() {
+			var res = new SDResult { ThreadInformation = new Dictionary<uint, SDThread>() };
+			res.ThreadInformation[1] = new SDThread(1) {
+				StackTrace = new SDCombinedStackTrace(new List<SDCombinedStackFrame>() {
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyErrorFrameA", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "app.dll", "MyAppFrameA", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "app.dll", "MyAppFrameB", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameA", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameB", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MySystemFrameA", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasdfasdfasdf.dll", "MyFrameasdfasdfasdfasdfaswsdfgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdfghdfhdfgh.dll", "MyFramewasdfasdfasdfasdfasddgfsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldfghdfghdfgh.dll", "MyFramewoasdfasdfasdfasdfasdfasdfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasdfasdfasdf.dll", "MyFrameasdf2asdfasdfasdfas1wsdfgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdfghdfhdfgh.dll", "MyFramewasdfasdfasdfasdfas2ddgfsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldf1ghdfghdfgh.dll", "MyFramewo2asdfasdfasdfasdfas3dfasdfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasd2fasdfasdf.dll", "MyFrameasdfasdfasdfasdfaswsd3fgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdfg3hdfhdfgh.dll", "MyFramewa3sdfasdfasdfasdfasddg45fsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldfghd455fghdfgh.dll", "MyFramewoasdfasdfasdfasdfasdfas6dfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasdfa6sdfasdf.dll", "MyFram3easdfasdfasdfasdfaswsdfgsd7fgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll5sdfghdfhdfgh.dll", "MyFram3ewasdfasdfasdfasdfasddgfsdf8orkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldf4ghdfghdfgh.dll", "MyFramewoasdfasdfasdfasdfasdfasdfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasdfasdfasdf.dll", "MyFrame3asdfasdfasdfasdfasw3sdfgsdfg90sdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdf5ghdfhdfgh.dll", "MyFram3ewasdfasdfasdfasdfasddgfsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldfg4hdfghdfgh.dll", "MyFramewoasdfasdfasdfasdfasdfasdfsdf08gdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasd3fasdfasdf.dll", "MyFra3measdfasdfa3sdfasdfasw3sdfgsdfgsdgo8rkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdf2hdfhdfgh.dll", "MyFramewasdfasdfasdfasdfasddgfsdforkFra5meC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldfgh4fghdfgh.dll", "MyFramewoasdfasdfasdfasdfasdfasdfsdfgdsf66gsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasdfasdfasdf.dll", "MyFrameasdfasdfasdf3asdfaswsdfgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdf5ghdfhdfgh.dll", "MyFramewasdfasdfasdfasdfasd3dgfsdforkFrameC2", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldfghdfghdfgh.dll", "MyFr1amewoasdfa3sdfasdfasdfasdfasdfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasd3f3asdfasdf.dll", "MyFra23measdfasdfasdfasdfaswsdfgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdfghdfhdfgh.dll", "MyFrame3wasdfasdfasdfasdfasddgfsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldfgh4dfghdfgh.dll", "MyFramew4oasdfasd33fasdfa3sdfasdfasdfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlla3sdfasdfasdf.dll", "MyFrameas4dfasdfasd3fasdfaswsdfgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdfg4hdfhdfgh.dll", "MyFramewasdfasdfasdfa3sdfasddgfsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldfghd3fghdfgh.dll", "MyFramewoa2sdfasdfas3dfa3sdfasdfasdfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasd3f4asdfasdf.dll", "MyFrameasdf56asdfasdf3asdfaswsdfgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsdfgh356fhdfgh.dll", "MyFramewasdf3asdfasd3fasdfasddgfsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldfgh7dfg3hdfgh.dll", "MyFramewoasdfasd3fasdfasdfasdfasdfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllasdfa6s3dfasdf.dll", "MyFrameas3dfas2dfasdfasdfaswsdfgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdl3lsdfg7hdfhdfgh.dll", "MyFramewas3d3fasdf3asdfasdfasddgfsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldf3g7hdfghdfgh.dll", "MyFramewoasdfa4s3dfa33sdfaswsdfgsdfgsdgorkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdllsd7fgh3dfhdfgh.dll", "MyFramewasdfasdf4asdfa3sdfasddgfsdforkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdlldf7ghdfghd3fgh.dll", "MyFramewoasdfasdf3asdfas3dfasdfasdfsdfgdsfgsrkFrameC", 123, 456, 789, 1011, 1213, null),
+					}),
+				LastException = new SDClrException {
+					Message = "Thread in invalid state.",
+					Type = "System.Threading.ThreadStateException"
+				}
+			};
+			AddTagToFrameAndThread(res, SDTag.NativeExceptionTag);
+
+			res.LastEvent = new SDLastEvent {
+				Type = "EXCEPTION",
+				ThreadId = 133,
+				Description = "Break instruction exception - code 80000003 (first/second chance not available)"
+			};
+			return res;
+		}
+
+		private static void AddTagToFrameAndThread(SDResult result, SDTag tag) {
+			result.ThreadInformation[1].Tags.Add(tag);
+			result.ThreadInformation[1].StackTrace[0].Tags.Add(tag);
+		}
+
+		[Benchmark]
+		public void CreateMiniInfo() {
+			// 128 bytes
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+			Console.WriteLine("hashed: " + MemUsageHashed());
+		}
+
+		private long MemUsageHashed() {
+			var before = GC.GetTotalMemory(true);
+			var x = CrashSimilarity.SDResultToMiniInfo(sdresult);
+			var after = GC.GetTotalMemory(true);
+			return after - before;
+		}
+	}
+}

--- a/src/SuperDumpService.Benchmark/Benchmarks/SimilarityCalculationBenchmarks.cs
+++ b/src/SuperDumpService.Benchmark/Benchmarks/SimilarityCalculationBenchmarks.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using SuperDumpService.Models;
+using SuperDumpService.Helpers;
 
 namespace SuperDumpService.Benchmark.Benchmarks {
 
@@ -14,34 +16,32 @@ namespace SuperDumpService.Benchmark.Benchmarks {
 			dump1 = new DumpMiniInfo {
 				DumpSimilarityInfoVersion = 2,
 				Exception = new ExceptionMiniInfo {
-					Message = "Thread in invalid state.",
-					Type = "System.Threading.ThreadStateException"
+					MessageHash = "Thread in invalid state.".GetStableHashCode(),
+					TypeHash = "System.Threading.ThreadStateException".GetStableHashCode()
 				},
 				FaultingThread = new ThreadMiniInfo {
-					DistinctModules = new string[] { "ntdll", "kernelbase", "ptsrv", "msvcr", "kernel" },
-					DistrinctFrames = new string[] { "ntalpcsendwaitreceiveport", "sendmessagetowerservice", "reportexceptioninternal", "rtlreportexceptionhelper", "rtlreportexception", "ldrpcalloutexceptionfilter", "ldrpprocessdetachnode", "ldrpunloadnode", "ldrpdecrementmoduleloadcountex", "ldrunloaddll", "freelibrary", "hookfreelibrary", "unknown", "exit", "basethreadinitthunk", "rtluserthreadstart" }
+					DistinctModuleHashes = new string[] { "ntdll", "kernelbase", "ptsrv", "msvcr", "kernel" }.Select(x => x.GetStableHashCode()).ToArray(),
+					DistinctFrameHashes = new string[] { "ntalpcsendwaitreceiveport", "sendmessagetowerservice", "reportexceptioninternal", "rtlreportexceptionhelper", "rtlreportexception", "ldrpcalloutexceptionfilter", "ldrpprocessdetachnode", "ldrpunloadnode", "ldrpdecrementmoduleloadcountex", "ldrunloaddll", "freelibrary", "hookfreelibrary", "unknown", "exit", "basethreadinitthunk", "rtluserthreadstart" }.Select(x => x.GetStableHashCode()).ToArray()
 				},
-				LastEvent = new SuperDump.Models.SDLastEvent {
-					Type = "EXCEPTION",
-					ThreadId = 177,
-					Description = "Break instruction exception - code 80000003 (first/second chance not available)"
+				LastEvent = new LastEventMiniInfo {
+					TypeHash = "EXCEPTION".GetStableHashCode(),
+					DescriptionHash = "Break instruction exception - code 80000003 (first/second chance not available)".GetStableHashCode()
 				}
 			};
 
 			dump2 = new DumpMiniInfo {
 				DumpSimilarityInfoVersion = 2,
 				Exception = new ExceptionMiniInfo {
-					Message = "Thread in invalid state.",
-					Type = "System.Threading.ThreadStateException"
+					MessageHash = "Thread in invalid state.".GetStableHashCode(),
+					TypeHash = "System.Threading.ThreadStateException".GetStableHashCode()
 				},
 				FaultingThread = new ThreadMiniInfo {
-					DistinctModules = new string[] { "someotherlibrary", "ntdll", "kernelbase", "ptsrv", "msvcr", "kernel" },
-					DistrinctFrames = new string[] { "someotherstackframe", "yetanotherunknown", "reportexceptioninternal", "rtlreportexceptionhelper", "rtlreportexception", "ldrpcalloutexceptionfilter", "ldrpprocessdetachnode", "ldrpunloadnode", "ldrpdecrementmoduleloadcountex", "ldrunloaddll", "freelibrary", "hookfreelibrary", "unknown", "exit", "basethreadinitthunk", "rtluserthreadstart" }
+					DistinctModuleHashes = new string[] { "someotherlibrary", "ntdll", "kernelbase", "ptsrv", "msvcr", "kernel" }.Select(x => x.GetStableHashCode()).ToArray(),
+					DistinctFrameHashes = new string[] { "someotherstackframe", "yetanotherunknown", "reportexceptioninternal", "rtlreportexceptionhelper", "rtlreportexception", "ldrpcalloutexceptionfilter", "ldrpprocessdetachnode", "ldrpunloadnode", "ldrpdecrementmoduleloadcountex", "ldrunloaddll", "freelibrary", "hookfreelibrary", "unknown", "exit", "basethreadinitthunk", "rtluserthreadstart" }.Select(x => x.GetStableHashCode()).ToArray()
 				},
-				LastEvent = new SuperDump.Models.SDLastEvent {
-					Type = "EXCEPTION",
-					ThreadId = 133,
-					Description = "Break instruction exception - code 80000003 (first/second chance not available)"
+				LastEvent = new LastEventMiniInfo {
+					TypeHash = "EXCEPTION".GetStableHashCode(),
+					DescriptionHash = "Break instruction exception - code 80000003 (first/second chance not available)".GetStableHashCode()
 				}
 			};
 
@@ -49,13 +49,12 @@ namespace SuperDumpService.Benchmark.Benchmarks {
 				DumpSimilarityInfoVersion = 2,
 				Exception = null,
 				FaultingThread = new ThreadMiniInfo {
-					DistinctModules = new string[] { "clr", "mscorlib", "simpleinjector", "unknown", "lineosweb", "", "systemweb", "webengine", "iiscore", "kernel", "ntdll" },
-					DistrinctFrames = new string[] { "sigtypecontextequal", "eehashtablebasesigtypecontextconsteeinstantiationhashtablehelperfinditem", "eehashtablebasesigtypecontextconsteeinstantiationhashtablehelpergetvalue", "methodcallgraphpreparerrun", "preparemethoddesc", "reflectioninvocationpreparedelegatehelper", "reflectioninvocationpreparedelegate", "mscorlibdllunknown", "simpleinjectordllunknown", "unknown", "lineoswebdllunknown", "calldescrworkerinternal", "calldescrworkerwithhandler", "calldescrworkerreflectionwrapper", "runtimemethodhandleinvokemethod", "debuggerumcatchhandlerframe", "systemwebdllunknown", "inlinedcallframe", "wmgdhandlerprocessnotification", "wmgdhandlerdowork", "requestdowork", "cmgdenghttpmoduleonacquirerequeststate", "notificationcontextrequestdowork", "notificationcontextcallmodulesinternal", "notificationcontextcallmodules", "notificationmaindowork", "wcontextbasecontinuenotificationloop", "wcontextbaseindicatecompletion", "wmgdhandlerindicatecompletion", "mgdindicatecompletion", "domainneutralilstubclassilstubpinvoke", "ummthunkwrapper", "threaddoadcallback", "contexttransitionframe", "ummdoadcallback", "processnotificationcallback", "unmanagedperappdomaintpcountdispatchworkitem", "threadpoolmgrexecuteworkrequest", "threadpoolmgrworkerthreadstart", "threadintermediatethreadproc", "basethreadinitthunk", "rtluserthreadstart" }
+					DistinctModuleHashes = new string[] { "clr", "mscorlib", "simpleinjector", "unknown", "lineosweb", "", "systemweb", "webengine", "iiscore", "kernel", "ntdll" }.Select(x => x.GetStableHashCode()).ToArray(),
+					DistinctFrameHashes = new string[] { "sigtypecontextequal", "eehashtablebasesigtypecontextconsteeinstantiationhashtablehelperfinditem", "eehashtablebasesigtypecontextconsteeinstantiationhashtablehelpergetvalue", "methodcallgraphpreparerrun", "preparemethoddesc", "reflectioninvocationpreparedelegatehelper", "reflectioninvocationpreparedelegate", "mscorlibdllunknown", "simpleinjectordllunknown", "unknown", "lineoswebdllunknown", "calldescrworkerinternal", "calldescrworkerwithhandler", "calldescrworkerreflectionwrapper", "runtimemethodhandleinvokemethod", "debuggerumcatchhandlerframe", "systemwebdllunknown", "inlinedcallframe", "wmgdhandlerprocessnotification", "wmgdhandlerdowork", "requestdowork", "cmgdenghttpmoduleonacquirerequeststate", "notificationcontextrequestdowork", "notificationcontextcallmodulesinternal", "notificationcontextcallmodules", "notificationmaindowork", "wcontextbasecontinuenotificationloop", "wcontextbaseindicatecompletion", "wmgdhandlerindicatecompletion", "mgdindicatecompletion", "domainneutralilstubclassilstubpinvoke", "ummthunkwrapper", "threaddoadcallback", "contexttransitionframe", "ummdoadcallback", "processnotificationcallback", "unmanagedperappdomaintpcountdispatchworkitem", "threadpoolmgrexecuteworkrequest", "threadpoolmgrworkerthreadstart", "threadintermediatethreadproc", "basethreadinitthunk", "rtluserthreadstart" }.Select(x => x.GetStableHashCode()).ToArray()
 				},
-				LastEvent = new SuperDump.Models.SDLastEvent {
-					Type = "EXCEPTION",
-					ThreadId = 55,
-					Description = "Access violation - code c0000005 (first/second chance not available)"
+				LastEvent = new LastEventMiniInfo {
+					TypeHash = "EXCEPTION".GetStableHashCode(),
+					DescriptionHash = "Access violation - code c0000005 (first/second chance not available)".GetStableHashCode()
 				}
 			};
 		}

--- a/src/SuperDumpService.Benchmark/Benchmarks/SimilarityServiceBenchmarks.cs
+++ b/src/SuperDumpService.Benchmark/Benchmarks/SimilarityServiceBenchmarks.cs
@@ -49,7 +49,7 @@ namespace SuperDumpService.Benchmark.Benchmarks {
 
 			// populate miniinfo cache
 			for (int i = 0; i < N; i++) {
-				await this.dumpRepo.GetMiniInfo(new DumpIdentifier($"bundle{i}", $"dump{i}"));
+				await this.dumpRepo.GetMiniInfo(DumpIdentifier.Create($"bundle{i}", $"dump{i}"));
 			}
 			this.dumpRepo.SetIsPopulated();
 
@@ -92,7 +92,7 @@ namespace SuperDumpService.Benchmark.Benchmarks {
 
 		[Benchmark]
 		public void ManySimilar() {
-			similarityService.CalculateSimilarity(dumpRepo.Get(new DumpIdentifier("bundle1", "dump1")), true, DateTime.MinValue);
+			similarityService.CalculateSimilarity(dumpRepo.Get(DumpIdentifier.Create("bundle1", "dump1")), true, DateTime.MinValue);
 		}
 	}
 }

--- a/src/SuperDumpService.Benchmark/Fakes/FakeDumpStorage.cs
+++ b/src/SuperDumpService.Benchmark/Fakes/FakeDumpStorage.cs
@@ -11,7 +11,7 @@ using SuperDumpService.Services;
 namespace SuperDumpService.Benchmarks.Fakes {
 	internal class FakeDump {
 		public DumpMetainfo MetaInfo { get; set; }
-		public DumpMiniInfo MiniInfo { get; set; }
+		public DumpMiniInfo? MiniInfo { get; set; }
 		public SDResult Result { get; set; }
 		public SDFileInfo FileInfo { get; set; }
 
@@ -80,7 +80,7 @@ namespace SuperDumpService.Benchmarks.Fakes {
 
 		public async Task<DumpMiniInfo> ReadMiniInfo(DumpIdentifier id) {
 			if (DelaysEnabled) await Task.Delay(READ_MINIINFO_DELAY_MS);
-			return await Task.FromResult(fakeDumpsDict[id].MiniInfo);
+			return await Task.FromResult(fakeDumpsDict[id].MiniInfo.Value);
 		}
 
 		public async Task<SDResult> ReadResults(DumpIdentifier id) {

--- a/src/SuperDumpService.Benchmark/Program.cs
+++ b/src/SuperDumpService.Benchmark/Program.cs
@@ -8,7 +8,7 @@ using SuperDumpService.Benchmark.Benchmarks;
 
 namespace SuperDumpService.Benchmark {
 	public class Program {
-		public static async Task Main(string[] args) {
+		public static void Main(string[] args) {
 
 			//var b = new SimilarityServiceBenchmarks();
 			//await b.GlobalSetup();
@@ -16,6 +16,10 @@ namespace SuperDumpService.Benchmark {
 			//b.ManySimilar();
 			//b.ManySimilar();
 			//b.ManySimilar();
+
+			//var x = new MiniInfoBenchmarks();
+			//x.GlobalSetup();
+			//x.CreateMiniInfo();
 
 			//BenchmarkRunner.Run<SimilarityCalculationBenchmarks>();
 			//BenchmarkRunner.Run<SimilarityServiceBenchmarks>();

--- a/src/SuperDumpService/Controllers/AdminController.cs
+++ b/src/SuperDumpService/Controllers/AdminController.cs
@@ -52,7 +52,7 @@ namespace SuperDumpService.Controllers {
 				return View(null);
 			}
 			logger.LogDumpAccess("TriggerSimilarityAnalysis", HttpContext, bundleInfo, dumpId);
-			similarityService.ScheduleSimilarityAnalysis(new DumpIdentifier(bundleId, dumpId), true, DateTime.MinValue);
+			similarityService.ScheduleSimilarityAnalysis(DumpIdentifier.Create(bundleId, dumpId), true, DateTime.MinValue);
 			return RedirectToAction("Report", "Home", new { bundleId = bundleId, dumpId = dumpId }); // View("/Home/Report", new ReportViewModel(bundleId, dumpId));
 		}
 

--- a/src/SuperDumpService/Controllers/HomeController.cs
+++ b/src/SuperDumpService/Controllers/HomeController.cs
@@ -227,14 +227,14 @@ namespace SuperDumpService.Controllers {
 			}
 
 			logger.LogDumpAccess("Start Interactive Mode", HttpContext, bundleInfo, dumpId);
-			var id = new DumpIdentifier(bundleId, dumpId);
+			var id = DumpIdentifier.Create(bundleId, dumpId);
 			return View(new InteractiveViewModel() { Id = id, DumpInfo = dumpRepo.Get(id), Command = cmd });
 		}
 
 		[HttpGet(Name = "Report")]
 		public async Task<IActionResult> Report(string bundleId, string dumpId) {
 			ViewData["Message"] = "Get Report";
-			var id = new DumpIdentifier(bundleId, dumpId);
+			var id = DumpIdentifier.Create(bundleId, dumpId);
 
 			var bundleInfo = superDumpRepo.GetBundle(bundleId);
 			if (bundleInfo == null) {
@@ -261,7 +261,7 @@ namespace SuperDumpService.Controllers {
 			// don't add relationships when the repo is not ready yet. it might take some time with large amounts.
 			IEnumerable<KeyValuePair<DumpMetainfo, double>> similarDumps =
 				!relationshipRepo.IsPopulated ? Enumerable.Empty<KeyValuePair<DumpMetainfo, double>>() :
-				(await relationshipRepo.GetRelationShips(new DumpIdentifier(bundleId, dumpId)))
+				(await relationshipRepo.GetRelationShips(DumpIdentifier.Create(bundleId, dumpId)))
 					.Select(x => new KeyValuePair<DumpMetainfo, double>(dumpRepo.Get(x.Key), x.Value)).Where(dump => dump.Key != null);
 
 			return base.View(new ReportViewModel(id) {
@@ -319,7 +319,7 @@ namespace SuperDumpService.Controllers {
 				logger.LogNotFound("DownloadFile: Bundle not found", HttpContext, "BundleId", bundleId);
 				return View(null);
 			}
-			var file = dumpStorage.GetFile(new DumpIdentifier(bundleId, dumpId), filename);
+			var file = dumpStorage.GetFile(DumpIdentifier.Create(bundleId, dumpId), filename);
 			if (file == null) {
 				logger.LogNotFound("DownloadFile: File not found", HttpContext, "Filename", filename);
 				throw new ArgumentException("could not find file");
@@ -356,7 +356,7 @@ namespace SuperDumpService.Controllers {
 				return View(null);
 			}
 			logger.LogDumpAccess("Rerun", HttpContext, bundleInfo, dumpId);
-			var id = new DumpIdentifier(bundleId, dumpId);
+			var id = DumpIdentifier.Create(bundleId, dumpId);
 			superDumpRepo.RerunAnalysis(id);
 			return View(new ReportViewModel(id));
 		}

--- a/src/SuperDumpService/Controllers/SimilarityController.cs
+++ b/src/SuperDumpService/Controllers/SimilarityController.cs
@@ -37,9 +37,6 @@ namespace SuperDumpService.Controllers
 				var res1 = await similarityService.GetOrCreateMiniInfo(id1);
 				var res2 = await similarityService.GetOrCreateMiniInfo(id2);
 
-				if (res1 == null || res2 == null) {
-					return View(new SimilarityModel($"could not compare dumps."));
-				}
 				logger.LogSimilarityEvent("CompareDumps", HttpContext, bundleId1, dumpId1, bundleId2, dumpId2);
 				var similarity = CrashSimilarity.Calculate(res1, res2);
 				return View(new SimilarityModel(new DumpIdentifier(bundleId1, dumpId2), new DumpIdentifier(bundleId2, dumpId2), similarity));

--- a/src/SuperDumpService/Controllers/SimilarityController.cs
+++ b/src/SuperDumpService/Controllers/SimilarityController.cs
@@ -31,15 +31,15 @@ namespace SuperDumpService.Controllers
 		[HttpGet]
 		public async Task<IActionResult> CompareDumps(string bundleId1, string dumpId1, string bundleId2, string dumpId2) {
 			try {
-				var id1 = new DumpIdentifier(bundleId1, dumpId1);
-				var id2 = new DumpIdentifier(bundleId2, dumpId2);
+				var id1 = DumpIdentifier.Create(bundleId1, dumpId1);
+				var id2 = DumpIdentifier.Create(bundleId2, dumpId2);
 
 				var res1 = await similarityService.GetOrCreateMiniInfo(id1);
 				var res2 = await similarityService.GetOrCreateMiniInfo(id2);
 
 				logger.LogSimilarityEvent("CompareDumps", HttpContext, bundleId1, dumpId1, bundleId2, dumpId2);
 				var similarity = CrashSimilarity.Calculate(res1, res2);
-				return View(new SimilarityModel(new DumpIdentifier(bundleId1, dumpId2), new DumpIdentifier(bundleId2, dumpId2), similarity));
+				return View(new SimilarityModel(DumpIdentifier.Create(bundleId1, dumpId2), DumpIdentifier.Create(bundleId2, dumpId2), similarity));
 			} catch (Exception e) {
 				return View(new SimilarityModel($"exception while comparing: {e.ToString()}"));
 			}

--- a/src/SuperDumpService/Helpers/Utility.cs
+++ b/src/SuperDumpService/Helpers/Utility.cs
@@ -311,4 +311,21 @@ namespace SuperDumpService.Helpers {
 				.GetResult();
 	}
 
+	public static class StringExtensionMethods {
+		public static int GetStableHashCode(this string str) {
+			unchecked {
+				int hash1 = 5381;
+				int hash2 = hash1;
+
+				for (int i = 0; i < str.Length && str[i] != '\0'; i += 2) {
+					hash1 = ((hash1 << 5) + hash1) ^ str[i];
+					if (i == str.Length - 1 || str[i + 1] == '\0')
+						break;
+					hash2 = ((hash2 << 5) + hash2) ^ str[i + 1];
+				}
+
+				return hash1 + (hash2 * 1566083941);
+			}
+		}
+	}
 }

--- a/src/SuperDumpService/Models/CrashSimilarity.cs
+++ b/src/SuperDumpService/Models/CrashSimilarity.cs
@@ -16,7 +16,7 @@ namespace SuperDumpService.Models {
 		// increment this version and mini-infos will be automatically re-created on the fly
 		//   version 1: initial version
 		//   version 2: removed ModuleName from stackframe comparison
-		//   version 2: hashes instead of strings. breaking change. need to re-create all mini-infos.
+		//   version 3: hashes instead of strings. breaking change. need to re-create all mini-infos.
 		public const int MiniInfoVersion = 3;
 
 		// there is a number of dimensions, each dimension has it's own similarity value of 0.0-1.0

--- a/src/SuperDumpService/Models/DumpIdentifier.cs
+++ b/src/SuperDumpService/Models/DumpIdentifier.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace SuperDumpService.Models {
 	public sealed class DumpIdentifier : IEquatable<DumpIdentifier> {
@@ -67,6 +69,32 @@ namespace SuperDumpService.Models {
 					return newId;
 				}
 			}
+		}
+	}
+
+	/// <summary>
+	/// custom serializer to write in format "bundleId:dumpId"
+	/// uses object pool
+	/// </summary>
+	public class DumpIdentifierConverter : JsonConverter {
+		public override bool CanConvert(Type objectType) {
+			return (objectType == typeof(DumpIdentifier));
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) {
+			string s = (string)reader.Value;
+			if (s == null) return null;
+			var parts = s.Split(":");
+			if (parts.Length != 2) return null;
+			return DumpIdentifier.Create(parts[0], parts[1]);
+		}
+
+		public override bool CanWrite {
+			get { return true; }
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
+			writer.WriteValue(value.ToString());
 		}
 	}
 }

--- a/src/SuperDumpService/Models/DumpMetainfo.cs
+++ b/src/SuperDumpService/Models/DumpMetainfo.cs
@@ -10,7 +10,7 @@ namespace SuperDumpService.Models {
 		public string BundleId { get; set; }
 		public string DumpId { get; set; }
 		[JsonIgnore]
-		public DumpIdentifier Id => new DumpIdentifier(BundleId, DumpId);
+		public DumpIdentifier Id => DumpIdentifier.Create(BundleId, DumpId);
 		public string DumpFileName { get; set; } // original filename. just informational.
 		public DumpType DumpType { get; set; } = DumpType.WindowsDump; // default to windows, for compatibility to existing repos (which will only contain windows dumps)
 		public DateTime Created { get; set; }

--- a/src/SuperDumpService/Models/DumpMiniInfo.cs
+++ b/src/SuperDumpService/Models/DumpMiniInfo.cs
@@ -1,25 +1,42 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using SuperDump.Models;
 
 namespace SuperDumpService.Models {
-	public class DumpMiniInfo {
+	/// <summary>
+	/// This class aims to provide data for similarity detection, but aims to be as small as possible (memory footprint)
+	/// </summary>
+	/// 
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	public struct DumpMiniInfo {
+		/// <summary>
+		/// version 3: Hashes instead of strings
+		/// </summary>
 		public int DumpSimilarityInfoVersion { get; set; }
-		public ThreadMiniInfo FaultingThread { get; set; }
-		public SDLastEvent LastEvent { get; set; }
-		public ExceptionMiniInfo Exception { get; set; }
 
+		public ThreadMiniInfo? FaultingThread { get; set; }
+		public LastEventMiniInfo? LastEvent { get; set; }
+		public ExceptionMiniInfo? Exception { get; set; }
 	}
 
-	public class ThreadMiniInfo {
-		public string[] DistinctModules { get; set; }
-		public string[] DistrinctFrames { get; set; }
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	public struct ThreadMiniInfo {
+		public int[] DistinctModuleHashes { get; set; }
+		public int[] DistinctFrameHashes { get; set; }
 	}
 
-	public class ExceptionMiniInfo {
-		public string Type { get; set; }
-		public string Message { get; set; }
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	public struct ExceptionMiniInfo {
+		public int? TypeHash { get; set; }
+		public int? MessageHash { get; set; }
+	}
+
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	public struct LastEventMiniInfo {
+		public int? TypeHash { get; set; }
+		public int? DescriptionHash { get; set; }
 	}
 }

--- a/src/SuperDumpService/Services/DumpStorageFilebased.cs
+++ b/src/SuperDumpService/Services/DumpStorageFilebased.cs
@@ -55,6 +55,7 @@ namespace SuperDumpService.Services {
 			return File.Exists(pathHelper.GetDumpMiniInfoPath(id));
 		}
 
+		// throws if miniinfo not found
 		public async Task<DumpMiniInfo> ReadMiniInfo(DumpIdentifier id) {
 			return JsonConvert.DeserializeObject<DumpMiniInfo>(await File.ReadAllTextAsync(pathHelper.GetDumpMiniInfoPath(id)));
 		}

--- a/src/SuperDumpService/Services/DumpStorageFilebased.cs
+++ b/src/SuperDumpService/Services/DumpStorageFilebased.cs
@@ -28,7 +28,7 @@ namespace SuperDumpService.Services {
 			var list = new List<DumpMetainfo>();
 			foreach (var dir in Directory.EnumerateDirectories(pathHelper.GetBundleDirectory(bundleId))) {
 				var dumpId = new DirectoryInfo(dir).Name;
-				var id = new DumpIdentifier(bundleId, dumpId);
+				var id = DumpIdentifier.Create(bundleId, dumpId);
 				var metainfoFilename = pathHelper.GetDumpMetadataPath(id);
 				if (!File.Exists(metainfoFilename)) {
 					// backwards compatibility, when Metadata files did not exist. read full json, then store metadata file

--- a/src/SuperDumpService/Services/RelationshipRepository.cs
+++ b/src/SuperDumpService/Services/RelationshipRepository.cs
@@ -45,7 +45,7 @@ namespace SuperDumpService.Services {
 					} catch (FileNotFoundException) {
 						// ignore.
 					} catch (Exception e) {
-						Console.WriteLine("error reading relationship file: " + e.ToString());
+						Console.WriteLine($"RelationshipRepository.Populate: Error reading relationship file for dump {dump.Id}: " + e.Message);
 						relationshipStorage.Wipe(dump.Id);
 					}
 				}));

--- a/src/SuperDumpService/Services/RelationshipStorageFilebased.cs
+++ b/src/SuperDumpService/Services/RelationshipStorageFilebased.cs
@@ -24,12 +24,12 @@ namespace SuperDumpService.Services {
 
 		public async Task StoreRelationships(DumpIdentifier id, IDictionary<DumpIdentifier, double> relationships) {
 			List<KeyValuePair<DumpIdentifier, double>> data = relationships.OrderByDescending(x => Math.Round(x.Value, 3)).ToList(); // use a list, otherwise complex key (DumpIdentifier) is problematic
-			await File.WriteAllTextAsync(pathHelper.GetRelationshipsPath(id), JsonConvert.SerializeObject(data));
+			await File.WriteAllTextAsync(pathHelper.GetRelationshipsPath(id), JsonConvert.SerializeObject(data, new DumpIdentifierConverter()));
 		}
 
 		public async Task<IDictionary<DumpIdentifier, double>> ReadRelationships(DumpIdentifier id) {
 			string text = await File.ReadAllTextAsync(pathHelper.GetRelationshipsPath(id));
-			var data = JsonConvert.DeserializeObject<List<KeyValuePair<DumpIdentifier, double>>>(text);
+			var data = JsonConvert.DeserializeObject<List<KeyValuePair<DumpIdentifier, double>>>(text, new DumpIdentifierConverter());
 			return data.ToDictionary(x => x.Key, y => y.Value);
 		}
 

--- a/src/SuperDumpService/SuperDumpService.csproj
+++ b/src/SuperDumpService/SuperDumpService.csproj
@@ -11,6 +11,7 @@
     <RestorePackages>true</RestorePackages>
 	<MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish> <!-- needed for RazorLight. see https://github.com/toddams/RazorLight/issues/118 -->
 	<UserSecretsId>B58C48DC-CC1B-4647-8E53-36B41078F1B8</UserSecretsId>
+	<LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Remove="Views\SlackMessage.cshtml" />


### PR DESCRIPTION
 * Changed MiniInfo to only contain hashes, instead of strings to save memory.
 * DumpIdentifier objects are now pooled. Especially in RelationshipRepository, the same DumpIdentifier would be used a number of times.