### PR TITLE
Slacknotificationservice tests

### DIFF
--- a/src/SuperDump.sln
+++ b/src/SuperDump.sln
@@ -41,6 +41,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SuperDumpService.Test", "Su
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SuperDumpService.Benchmark", "SuperDumpService.Benchmark\SuperDumpService.Benchmark.csproj", "{6C014CE6-464F-4420-A9AB-1D4E3DFFD48C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SuperDumpService.Test.Fakes", "SuperDumpService.Test.Fakes\SuperDumpService.Test.Fakes.csproj", "{C81E6045-4C5F-4978-A897-85B5F470B5F3}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		SuperDump.Analyzer.Common\SuperDump.Analyzer.Common.projitems*{0dd4da67-4e55-4ee1-9030-5a69d8cdc6b4}*SharedItemsImports = 4
@@ -197,6 +199,18 @@ Global
 		{6C014CE6-464F-4420-A9AB-1D4E3DFFD48C}.Release|x64.Build.0 = Release|Any CPU
 		{6C014CE6-464F-4420-A9AB-1D4E3DFFD48C}.Release|x86.ActiveCfg = Release|Any CPU
 		{6C014CE6-464F-4420-A9AB-1D4E3DFFD48C}.Release|x86.Build.0 = Release|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Debug|x64.Build.0 = Debug|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Debug|x86.Build.0 = Debug|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Release|x64.ActiveCfg = Release|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Release|x64.Build.0 = Release|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Release|x86.ActiveCfg = Release|Any CPU
+		{C81E6045-4C5F-4978-A897-85B5F470B5F3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SuperDumpService.Benchmark/SuperDumpService.Benchmark.csproj
+++ b/src/SuperDumpService.Benchmark/SuperDumpService.Benchmark.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SuperDumpService.Test.Fakes\SuperDumpService.Test.Fakes.csproj" />
     <ProjectReference Include="..\SuperDumpService\SuperDumpService.csproj" />
   </ItemGroup>
 

--- a/src/SuperDumpService.Test.Fakes/FakeDumpStorage.cs
+++ b/src/SuperDumpService.Test.Fakes/FakeDumpStorage.cs
@@ -9,7 +9,7 @@ using SuperDumpService.Models;
 using SuperDumpService.Services;
 
 namespace SuperDumpService.Benchmarks.Fakes {
-	internal class FakeDump {
+	public class FakeDump {
 		public DumpMetainfo MetaInfo { get; set; }
 		public DumpMiniInfo? MiniInfo { get; set; }
 		public SDResult Result { get; set; }
@@ -17,7 +17,7 @@ namespace SuperDumpService.Benchmarks.Fakes {
 
 	}
 
-	internal class FakeDumpStorage : IDumpStorage {
+	public class FakeDumpStorage : IDumpStorage {
 		private readonly int READ_RESULT_DELAY_MS = 1;
 		private readonly int READ_MINIINFO_DELAY_MS = 1;
 		private readonly int WRITE_MINIINFO_DELAY_MS = 1;

--- a/src/SuperDumpService.Test.Fakes/FakeRelationshipStorage.cs
+++ b/src/SuperDumpService.Test.Fakes/FakeRelationshipStorage.cs
@@ -6,7 +6,7 @@ using SuperDumpService.Models;
 using SuperDumpService.Services;
 
 namespace SuperDumpService.Benchmarks.Fakes {
-	internal class FakeRelationshipStorage : IRelationshipStorage {
+	public class FakeRelationshipStorage : IRelationshipStorage {
 		private readonly int WRITE_RELATIONSHIPS_DELAY_MS = 1;
 
 		public bool DelaysEnabled { get; set; }

--- a/src/SuperDumpService.Test.Fakes/SuperDumpService.Test.Fakes.csproj
+++ b/src/SuperDumpService.Test.Fakes/SuperDumpService.Test.Fakes.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SuperDumpService\SuperDumpService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SuperDumpService.Test/SlackNotificationTests.cs
+++ b/src/SuperDumpService.Test/SlackNotificationTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using SuperDump.Models;
+using SuperDumpService.Benchmarks.Fakes;
+using SuperDumpService.Helpers;
+using SuperDumpService.Models;
+using SuperDumpService.Services;
+using Xunit;
+
+namespace SuperDumpService.Test {
+
+	public class SlackNotificationTests {
+
+		[Fact]
+		public async Task TestSlackNotification() {
+			var settings = Options.Create(new SuperDumpSettings());
+			var fakeDump = CreateFakeDump();
+			var pathHelper = new PathHelper("", "", "");
+			var dumpStorage = new FakeDumpStorage(new FakeDump[] { fakeDump });
+			var dumpRepo = new DumpRepository(dumpStorage, pathHelper);
+			var slackNotificationService = new SlackNotificationService(settings, dumpRepo);
+			var msg = await slackNotificationService.GetMessageModel(fakeDump.MetaInfo);
+
+			// these assertions are bare mininum for now. Could be improved.
+			Assert.Equal(1, msg.NumNativeExceptions);
+
+			var msgStr = await slackNotificationService.GetMessage(fakeDump.MetaInfo);
+			Assert.NotNull(msgStr);
+		}
+
+		private FakeDump CreateFakeDump() {
+			var res = new SDResult { ThreadInformation = new Dictionary<uint, SDThread>() };
+			res.ThreadInformation[1] = new SDThread(1) {
+				StackTrace = new SDCombinedStackTrace(new List<SDCombinedStackFrame>() {
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyErrorFrameA", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "app.dll", "MyAppFrameA", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "app.dll", "MyAppFrameB", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameA", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameB", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameC", 123, 456, 789, 1011, 1213, null),
+						new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MySystemFrameA", 123, 456, 789, 1011, 1213, null)
+					})
+			};
+			AddTagToFrameAndThread(res, SDTag.NativeExceptionTag);
+
+			res.SystemContext = new SDSystemContext {
+				ProcessArchitecture = "X64",
+				Modules = new List<SDModule> { new SDModule { FileName = "jvm.dll" } }
+			};
+
+			return new FakeDump {
+				MetaInfo = new DumpMetainfo { BundleId = $"bundle1", DumpId = $"dump1", Status = DumpStatus.Finished },
+				FileInfo = null,
+				Result = res,
+				MiniInfo = CrashSimilarity.SDResultToMiniInfo(res)
+			};
+		}
+
+		private static void AddTagToFrameAndThread(SDResult result, SDTag tag) {
+			result.ThreadInformation[1].Tags.Add(tag);
+			result.ThreadInformation[1].StackTrace[0].Tags.Add(tag);
+		}
+	}
+}

--- a/src/SuperDumpService.Test/SuperDumpService.Test.csproj
+++ b/src/SuperDumpService.Test/SuperDumpService.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
+		<PreserveCompilationContext>true</PreserveCompilationContext><!-- needed for RazorLight -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SuperDump.Common\SuperDump.Common.csproj" />
     <ProjectReference Include="..\SuperDumpModels\SuperDumpModels.csproj" />
+    <ProjectReference Include="..\SuperDumpService.Test.Fakes\SuperDumpService.Test.Fakes.csproj" />
     <ProjectReference Include="..\SuperDumpService\SuperDumpService.csproj" />
   </ItemGroup>
 

--- a/src/SuperDumpService/Services/SlackNotificationService.cs
+++ b/src/SuperDumpService/Services/SlackNotificationService.cs
@@ -40,45 +40,56 @@ namespace SuperDumpService.Services {
 		}
 
 		public async Task<string> GetMessage(DumpMetainfo dumpInfo) {
+			//var engine = new RazorLightEngineBuilder()
+				//.UseEmbeddedResourcesProject(typeof(SlackMessageViewModel))
+				//.UseMemoryCachingProvider()
+				//.Build();
+			var engine = new EngineFactory().ForEmbeddedResources(typeof(SlackMessageViewModel));
+			return await engine.CompileRenderAsync("SlackMessage", await GetMessageModel(dumpInfo));
+		}
+
+		public async Task<SlackMessageViewModel> GetMessageModel(DumpMetainfo dumpInfo) {
 			var model = new SlackMessageViewModel();
 
 			var res = await dumpRepo.GetResult(dumpInfo.Id);
-			
-			var engine = new EngineFactory().ForEmbeddedResources(typeof(SlackMessageViewModel));
+
 			model.TopProperties.Add(dumpInfo.DumpType == DumpType.WindowsDump ? "Windows" : "Linux");
 			model.DumpFilename = Path.GetFileName(dumpInfo.DumpFileName);
 			model.Url = $"{superDumpUrl}/Home/Report?bundleId={dumpInfo.BundleId}&dumpId={dumpInfo.DumpId}";
 			if (res != null) {
-				model.TopProperties.Add(res.SystemContext.ProcessArchitecture);
+				if (res.SystemContext != null) {
+					model.TopProperties.Add(res.SystemContext.ProcessArchitecture);
 
-				if (res.IsManagedProcess) model.TopProperties.Add(".NET");
-				if (res.SystemContext.Modules.Any(x => x.FileName.Contains("jvm.dll"))) model.TopProperties.Add("Java");
-				if (res.SystemContext.Modules.Any(x => x.FileName.Contains("jvm.so"))) model.TopProperties.Add("Java");
-				if (res.SystemContext.Modules.Any(x => x.FileName.Contains("iiscore.dll"))) model.TopProperties.Add("IIS");
-				if (res.SystemContext.Modules.Any(x => x.FileName.Contains("nginx.so"))) model.TopProperties.Add("NGINX");
-				if (res.SystemContext.Modules.Any(x => x.FileName.Contains("httpd/modules"))) model.TopProperties.Add("Apache");
-				if (res.SystemContext.Modules.Any(x => x.FileName.Contains("node.exe"))) model.TopProperties.Add("Node.js");
+					if (res.IsManagedProcess) model.TopProperties.Add(".NET");
+					if (res.SystemContext.Modules.Any(x => x.FileName.Contains("jvm.dll"))) model.TopProperties.Add("Java");
+					if (res.SystemContext.Modules.Any(x => x.FileName.Contains("jvm.so"))) model.TopProperties.Add("Java");
+					if (res.SystemContext.Modules.Any(x => x.FileName.Contains("iiscore.dll"))) model.TopProperties.Add("IIS");
+					if (res.SystemContext.Modules.Any(x => x.FileName.Contains("nginx.so"))) model.TopProperties.Add("NGINX");
+					if (res.SystemContext.Modules.Any(x => x.FileName.Contains("httpd/modules"))) model.TopProperties.Add("Apache");
+					if (res.SystemContext.Modules.Any(x => x.FileName.Contains("node.exe"))) model.TopProperties.Add("Node.js");
 
-				var agentModules = res.SystemContext.Modules.Where(x => x.Tags.Any(t => t.Equals(SDTag.DynatraceAgentTag))).Select(m => m.ToString());
-				model.AgentModules = agentModules.ToList();
+					var agentModules = res.SystemContext.Modules.Where(x => x.Tags.Any(t => t.Equals(SDTag.DynatraceAgentTag))).Select(m => m.ToString());
+					model.AgentModules = agentModules.ToList();
+				}
 
-				model.NumManagedExceptions = res.ThreadInformation.Count(x => x.Value.Tags.Any(t => t.Equals(SDTag.ManagedExceptionTag)));
-				model.NumNativeExceptions = res.ThreadInformation.Count(x => x.Value.Tags.Any(t => t.Equals(SDTag.NativeExceptionTag)));
-				model.NumAssertErrors = res.ThreadInformation.Count(x => x.Value.Tags.Any(t => t.Equals(SDTag.AssertionErrorTag)));
+				if (res.ThreadInformation != null) {
+					model.NumManagedExceptions = res.ThreadInformation.Count(x => x.Value.Tags.Any(t => t.Equals(SDTag.ManagedExceptionTag)));
+					model.NumNativeExceptions = res.ThreadInformation.Count(x => x.Value.Tags.Any(t => t.Equals(SDTag.NativeExceptionTag)));
+					model.NumAssertErrors = res.ThreadInformation.Count(x => x.Value.Tags.Any(t => t.Equals(SDTag.AssertionErrorTag)));
 
-				SDThread managedExceptionThread = res.ThreadInformation.Values.FirstOrDefault(x => x.Tags.Any(t => t.Equals(SDTag.ManagedExceptionTag)));
-				SDClrException clrException = managedExceptionThread?.LastException;
-				if (clrException != null) {
-					model.TopException = clrException.Type;
-					model.Stacktrace = clrException.StackTrace.ToString();
+					SDThread managedExceptionThread = res.ThreadInformation.Values.FirstOrDefault(x => x.Tags.Any(t => t.Equals(SDTag.ManagedExceptionTag)));
+					SDClrException clrException = managedExceptionThread?.LastException;
+					if (clrException != null) {
+						model.TopException = clrException.Type;
+						model.Stacktrace = clrException.StackTrace.ToString();
+					}
 				}
 
 				if (res.LastEvent != null && !res.LastEvent.Description.Contains("Break instruction")) { // break instruction events are useless
 					model.LastEvent = $"{res.LastEvent.Type}: {res.LastEvent.Description}";
 				}
 			}
-			
-			return await engine.CompileRenderAsync("SlackMessage", model);
+			return model;
 		}
 
 		private async Task SendMessage(string url, string msg) {

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -76,6 +76,9 @@ namespace SuperDumpService {
 
 			services.AddAntiforgery();
 
+			// asp.net core health checks
+			services.AddHealthChecks();
+
 			//configure DB
 			if (config.GetValue<bool>("UseInMemoryHangfireStorage")) {
 				services.AddHangfire(x => x.UseStorage(new Hangfire.MemoryStorage.MemoryStorage()));
@@ -244,6 +247,7 @@ namespace SuperDumpService {
 
 			app.UseSwagger();
 			app.UseSwaggerUi();
+			app.UseHealthChecks("/healthcheck");
 
 			LogProvider.SetCurrentLogProvider(new ColouredConsoleLogProvider());
 

--- a/src/SuperDumpService/SuperDumpService.csproj
+++ b/src/SuperDumpService/SuperDumpService.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
 		
     <PackageReference Include="ByteSize" Version="1.3.0" />


### PR DESCRIPTION
 * added a unit test for slacknotificationservice
 * added asp.net core healthchecks

The reason behind this is, we got some weird exceptions like these
```
Slack notifications failed: System.InvalidOperationException: Cannot find compilation library location for package 'Microsoft.AspNetCore.Diagnostics.HealthChecks'
   at Microsoft.Extensions.DependencyModel.CompilationLibrary.ResolveReferencePaths(ICompilationAssemblyResolver resolver, List`1 assemblies)
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
   at RazorLight.Compilation.DefaultMetadataReferenceManager.Resolve(DependencyContext dependencyContext)
   at RazorLight.Compilation.RoslynCompilationService.EnsureOptions()
   at RazorLight.Compilation.RoslynCompilationService.get_ParseOptions()
   at RazorLight.Compilation.RoslynCompilationService.CreateSyntaxTree(SourceText sourceText)
   at RazorLight.Compilation.RoslynCompilationService.CreateCompilation(String compilationContent, String assemblyName)
   at RazorLight.Compilation.RoslynCompilationService.CompileAndEmit(IGeneratedRazorTemplate razorTemplate)
   at RazorLight.Compilation.RoslynCompilationService.CompileAsync(IGeneratedRazorTemplate razorTemplate)
--- End of stack trace from previous location where exception was thrown ---
   at RazorLight.Compilation.TemplateFactoryProvider.CompileAsync(IGeneratedRazorTemplate razorTemplate)
   at RazorLight.Compilation.TemplateFactoryProvider.CreateFactoryAsync(String templateKey)
   at RazorLight.RazorLightEngine.CompileTemplateAsync(String key)
   at RazorLight.RazorLightEngine.CompileRenderAsync(String key, Object model, Type modelType, ExpandoObject viewBag)
   at SuperDumpService.Services.SlackNotificationService.GetMessage(DumpMetainfo dumpInfo) in C:\workspaces\priv\superdump-internal.git\src\SuperDumpService\Services\SlackNotificationService.cs:line 81
   at SuperDumpService.Services.SlackNotificationService.NotifyDumpAnalysisFinished(DumpMetainfo dumpInfo) in C:\workspaces\priv\superdump-internal.git\src\SuperDumpService\Services\SlackNotificationService.cs:line 32
Slack notifications failed: System.InvalidOperationException: Cannot find compilation library location for package 'Microsoft.AspNetCore.Diagnostics.HealthChecks'
   at Microsoft.Extensions.DependencyModel.CompilationLibrary.ResolveReferencePaths(ICompilationAssemblyResolver resolver, List`1 assemblies)
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
   at RazorLight.Compilation.DefaultMetadataReferenceManager.Resolve(DependencyContext dependencyContext)
   at RazorLight.Compilation.RoslynCompilationService.EnsureOptions()
   at RazorLight.Compilation.RoslynCompilationService.get_ParseOptions()
   at RazorLight.Compilation.RoslynCompilationService.CreateSyntaxTree(SourceText sourceText)
   at RazorLight.Compilation.RoslynCompilationService.CreateCompilation(String compilationContent, String assemblyName)
   at RazorLight.Compilation.RoslynCompilationService.CompileAndEmit(IGeneratedRazorTemplate razorTemplate)
   at RazorLight.Compilation.RoslynCompilationService.CompileAsync(IGeneratedRazorTemplate razorTemplate)
--- End of stack trace from previous location where exception was thrown ---
   at RazorLight.Compilation.TemplateFactoryProvider.CompileAsync(IGeneratedRazorTemplate razorTemplate)
   at RazorLight.Compilation.TemplateFactoryProvider.CreateFactoryAsync(String templateKey)
   at RazorLight.RazorLightEngine.CompileTemplateAsync(String key)
   at RazorLight.RazorLightEngine.CompileRenderAsync(String key, Object model, Type modelType, ExpandoObject viewBag)
   at SuperDumpService.Services.SlackNotificationService.GetMessage(DumpMetainfo dumpInfo) in C:\workspaces\priv\superdump-internal.git\src\SuperDumpService\Services\SlackNotificationService.cs:line 81
   at SuperDumpService.Services.SlackNotificationService.NotifyDumpAnalysisFinished(DumpMetainfo dumpInfo) in C:\workspaces\priv\superdump-internal.git\src\SuperDumpService\Services\SlackNotificationService.cs:line 32
```

Now I can easily verify that slack message generation works in general. The dependency resolution is fixed by just adding the health checks (it makes sense anyway).