### PR TITLE
JIRA rest api session handling and bugfixes

### DIFF
--- a/src/SuperDumpSelector/SuperDumpSelector.csproj
+++ b/src/SuperDumpSelector/SuperDumpSelector.csproj
@@ -95,7 +95,7 @@
       <Version>2.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Runtime">
-      <Version>1.0.0</Version>
+      <Version>1.0.2</Version>
     </PackageReference>
     <PackageReference Include="System.Console">
       <Version>4.3.1</Version>

--- a/src/SuperDumpService.Test.Fakes/FakeDumpStorage.cs
+++ b/src/SuperDumpService.Test.Fakes/FakeDumpStorage.cs
@@ -33,6 +33,8 @@ namespace SuperDumpService.Test.Fakes {
 
 		public bool DelaysEnabled { get; set; }
 
+		public FakeDumpStorage() : this(Enumerable.Empty<FakeDump>()) { }
+
 		public FakeDumpStorage(IEnumerable<FakeDump> fakeDumps) {
 			this.fakeDumpsDict = new Dictionary<DumpIdentifier, FakeDump>();
 			this.fakeBundlesDict = new Dictionary<string, FakeBundle>();

--- a/src/SuperDumpService.Test.Fakes/FakeJiraApiService.cs
+++ b/src/SuperDumpService.Test.Fakes/FakeJiraApiService.cs
@@ -12,7 +12,11 @@ namespace SuperDumpService.Test.Fakes {
 		private readonly object sync = new object();
 
 		public void SetFakeJiraIssues(string bundleId, IEnumerable<JiraIssueModel> jiraIssueModels) {
-			jiraIssueStore[bundleId] = jiraIssueModels;
+			if (jiraIssueModels == null) {
+				jiraIssueStore.Remove(bundleId, out var x);
+			} else {
+				jiraIssueStore[bundleId] = jiraIssueModels;
+			}
 		}
 
 		public Task<IEnumerable<JiraIssueModel>> GetBulkIssues(IEnumerable<string> issueKeys) {

--- a/src/SuperDumpService.Test/JiraIssueRepositoryTest.cs
+++ b/src/SuperDumpService.Test/JiraIssueRepositoryTest.cs
@@ -84,9 +84,9 @@ namespace SuperDumpService.Test {
 			Assert.Empty(jiraIssueRepository.GetIssues("bundle3"));
 
 			// fake, that in jira some bundles have been referenced in new issues
-			jiraApiService.SetFakeJiraIssues("bundle1", new JiraIssueModel[] { new JiraIssueModel("JRA-1111") });
-			jiraApiService.SetFakeJiraIssues("bundle2", new JiraIssueModel[] { new JiraIssueModel("JRA-2222"), new JiraIssueModel("JRA-3333"), new JiraIssueModel("JRA-4444") });
-			jiraApiService.SetFakeJiraIssues("bundle3", new JiraIssueModel[] { new JiraIssueModel("JRA-1111"), new JiraIssueModel("JRA-5555") });
+			jiraApiService.SetFakeJiraIssues("bundle1", new JiraIssueModel[] { new JiraIssueModel("JRA-1111") }); // same
+			jiraApiService.SetFakeJiraIssues("bundle2", new JiraIssueModel[] { new JiraIssueModel("JRA-2222"), new JiraIssueModel("JRA-4444") }); // one added, one removed
+			jiraApiService.SetFakeJiraIssues("bundle3", new JiraIssueModel[] { new JiraIssueModel("JRA-1111"), new JiraIssueModel("JRA-5555") }); // new
 
 			// trigger update of repository
 			await jiraIssueRepository.SearchBundleIssuesAsync(bundleRepo.GetAll(), true);
@@ -96,7 +96,6 @@ namespace SuperDumpService.Test {
 
 			Assert.Collection(jiraIssueRepository.GetIssues("bundle2"),
 				item => Assert.Equal("JRA-2222", item.Key),
-				item => Assert.Equal("JRA-3333", item.Key),
 				item => Assert.Equal("JRA-4444", item.Key));
 
 			Assert.Collection(jiraIssueRepository.GetIssues("bundle3"),
@@ -112,7 +111,6 @@ namespace SuperDumpService.Test {
 
 			Assert.Collection(res["bundle2"],
 				item => Assert.Equal("JRA-2222", item.Key),
-				item => Assert.Equal("JRA-3333", item.Key),
 				item => Assert.Equal("JRA-4444", item.Key));
 		}
 

--- a/src/SuperDumpService.Test/JiraIssueRepositoryTest.cs
+++ b/src/SuperDumpService.Test/JiraIssueRepositoryTest.cs
@@ -68,6 +68,7 @@ namespace SuperDumpService.Test {
 			// population
 			await jiraIssueStorage.Store("bundle1", new List<JiraIssueModel> { new JiraIssueModel("JRA-1111") });
 			await jiraIssueStorage.Store("bundle2", new List<JiraIssueModel> { new JiraIssueModel("JRA-2222"), new JiraIssueModel("JRA-3333") });
+			await jiraIssueStorage.Store("bundle9", new List<JiraIssueModel> { new JiraIssueModel("JRA-9999") });
 
 			await bundleRepo.Populate();
 			await jiraIssueRepository.Populate();
@@ -81,14 +82,17 @@ namespace SuperDumpService.Test {
 				item => Assert.Equal("JRA-2222", item.Key),
 				item => Assert.Equal("JRA-3333", item.Key));
 
+			Assert.Collection(jiraIssueRepository.GetIssues("bundle9"),
+				item => Assert.Equal("JRA-9999", item.Key));
+
 			Assert.Empty(jiraIssueRepository.GetIssues("bundle3"));
 
 			// fake, that in jira some bundles have been referenced in new issues
 			jiraApiService.SetFakeJiraIssues("bundle1", new JiraIssueModel[] { new JiraIssueModel("JRA-1111") }); // same
 			jiraApiService.SetFakeJiraIssues("bundle2", new JiraIssueModel[] { new JiraIssueModel("JRA-2222"), new JiraIssueModel("JRA-4444") }); // one added, one removed
 			jiraApiService.SetFakeJiraIssues("bundle3", new JiraIssueModel[] { new JiraIssueModel("JRA-1111"), new JiraIssueModel("JRA-5555") }); // new
+			jiraApiService.SetFakeJiraIssues("bundle9", null ); // removed jira issues
 
-			// trigger update of repository
 			await jiraIssueRepository.SearchBundleIssuesAsync(bundleRepo.GetAll(), true);
 
 			Assert.Collection(jiraIssueRepository.GetIssues("bundle1"),
@@ -102,8 +106,9 @@ namespace SuperDumpService.Test {
 				item => Assert.Equal("JRA-1111", item.Key),
 				item => Assert.Equal("JRA-5555", item.Key));
 
+			Assert.Empty(jiraIssueRepository.GetIssues("bundle9"));
 
-			var res = await jiraIssueRepository.GetAllIssuesByBundleIdsWithoutWait(new string[] { "bundle1", "bundle2", "bundle7", "bundle666" });
+			var res = await jiraIssueRepository.GetAllIssuesByBundleIdsWithoutWait(new string[] { "bundle1", "bundle2", "bundle7", "bundle666", "bundle9" });
 			Assert.Equal(2, res.Count());
 
 			Assert.Collection(res["bundle1"],
@@ -112,6 +117,11 @@ namespace SuperDumpService.Test {
 			Assert.Collection(res["bundle2"],
 				item => Assert.Equal("JRA-2222", item.Key),
 				item => Assert.Equal("JRA-4444", item.Key));
+
+
+			Assert.Empty(jiraIssueRepository.GetIssues("bundle7"));
+			Assert.Empty(jiraIssueRepository.GetIssues("bundle666"));
+			Assert.Empty(jiraIssueRepository.GetIssues("bundle9"));
 		}
 
 		private IEnumerable<FakeDump> CreateFakeDumps() {

--- a/src/SuperDumpService/JiraIntegrationSettings.cs
+++ b/src/SuperDumpService/JiraIntegrationSettings.cs
@@ -11,6 +11,7 @@ namespace SuperDumpService {
 		public int JiraBundleSearchLimit { get; set; }
 		public double JiraBundleSearchDelay { get; set; }
 		public TimeSpan JiraBundleSearchTimeSpan { get; set; }
+		public string JiraApiAuthUrl { get; set; }
 		public string JiraApiSearchUrl { get; set; }
 		public string JiraApiUsername { get; set; }
 		public string JiraApiPassword { get; set; }

--- a/src/SuperDumpService/Models/DumpIdentifier.cs
+++ b/src/SuperDumpService/Models/DumpIdentifier.cs
@@ -61,7 +61,6 @@ namespace SuperDumpService.Models {
 
 			public DumpIdentifier Allocate(string bundleId, string dumpId) {
 				int hash = $"{bundleId}:{dumpId}".GetHashCode();
-				if (pool.TryGetValue(hash, out DumpIdentifier id)) return id; // fast path
 				lock (sync) {
 					if (pool.TryGetValue(hash, out DumpIdentifier id2)) return id2;
 					var newId = new DumpIdentifier(bundleId, dumpId);

--- a/src/SuperDumpService/Services/JiraApiService.cs
+++ b/src/SuperDumpService/Services/JiraApiService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -13,6 +14,26 @@ using Newtonsoft.Json;
 using SuperDumpService.Models;
 
 namespace SuperDumpService.Services {
+	/// <summary>
+	/// Datastructure that Jira returns on authentication
+	/// </summary>
+	public class SessionInfo {
+		public Session session;
+		public LoginInfo loginInfo;
+
+		public class Session {
+			public string name;
+			public string value;
+		}
+
+		public class LoginInfo {
+			public int failedLoginCount;
+			public int loginCount;
+			public DateTime lastFailedLoginTime;
+			public DateTime previousLoginTime;
+		}
+	}
+
 	public class JiraApiService : IJiraApiService {
 		private const string JsonMediaType = "application/json";
 		private const string JiraIssueFields = "status,resolution";
@@ -21,13 +42,49 @@ namespace SuperDumpService.Services {
 		private readonly JiraIntegrationSettings settings;
 		private readonly HttpClient client;
 
+		public CookieContainer Cookies {
+			get { return HttpClientHandler.CookieContainer; }
+			set { HttpClientHandler.CookieContainer = value; }
+		}
+
+		public HttpClientHandler HttpClientHandler { get; set; }
+
+		public SessionInfo Session { get; set; }
+
 		public JiraApiService(IOptions<SuperDumpSettings> settings) {
 			this.settings = settings.Value.JiraIntegrationSettings;
 			if (this.settings == null) return;
-			client = new HttpClient();
+
+			HttpClientHandler = new HttpClientHandler {
+				AllowAutoRedirect = true,
+				UseCookies = true,
+				CookieContainer = new CookieContainer()
+			};
+
+			client = new HttpClient(HttpClientHandler);
 			client.DefaultRequestHeaders.Accept.Clear();
 			client.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(JsonMediaType));
-			client.DefaultRequestHeaders.Authorization = GetBasicAuthenticationHeader(this.settings.JiraApiUsername, this.settings.JiraApiPassword);
+		}
+
+		private async Task Authenticate() {
+			using (var authClient = new HttpClient()) {
+				var uriBuilder = new UriBuilder(settings.JiraApiAuthUrl);
+				var response = await authClient.PostAsJsonAsync(settings.JiraApiAuthUrl, new {
+					username = this.settings.JiraApiUsername,
+					password = this.settings.JiraApiPassword
+				});
+				var sessionInfo = await response.Content.ReadAsAsync<SessionInfo>();
+				this.Session = sessionInfo;
+				var cookieDomain = new Uri(new Uri(settings.JiraApiAuthUrl).GetLeftPart(UriPartial.Authority));
+				this.Cookies.Add(cookieDomain, new Cookie(sessionInfo.session.name, sessionInfo.session.value));
+			}
+		}
+
+		private async Task EnsureAuthentication() {
+			// reauthenticate every 10 minutes
+			if (Session == null || (DateTime.Now - Session.loginInfo.previousLoginTime).Minutes > 10) {
+				await Authenticate();
+			}
 		}
 
 		public async Task<IEnumerable<JiraIssueModel>> GetJiraIssues(string bundleId) {
@@ -49,10 +106,12 @@ namespace SuperDumpService.Services {
 			query["fields"] = JiraIssueFields;
 			uriBuilder.Query = query.ToString();
 
+			await EnsureAuthentication();
 			return await HandleResponse(await client.GetAsync(uriBuilder.ToString()));
 		}
 
-		private async Task<IEnumerable<JiraIssueModel>> JiraPostSearch(string queryString) {
+		private async Task<IEnumerable<JiraIssueModel>> JiraPostSearch(string queryString, int retry = 3) {
+			await EnsureAuthentication();
 			return await HandleResponse(await client.PostAsJsonAsync(settings.JiraApiSearchUrl, new {
 				jql = queryString,
 				fields = JiraIssueFieldsArray
@@ -64,11 +123,9 @@ namespace SuperDumpService.Services {
 				throw new HttpRequestException($"Jira api call {response.RequestMessage.RequestUri} returned status code {response.StatusCode}");
 			}
 			IEnumerable<JiraIssueModel> issues = (await response.Content.ReadAsAsync<JiraSearchResultModel>()).Issues;
-
 			foreach (JiraIssueModel issue in issues) {
 				issue.Url = settings.JiraIssueUrl + issue.Key;
 			}
-
 			return issues;
 		}
 


### PR DESCRIPTION
 * jira authentication now uses cookies to keep sessionid. this is to avoid login for every jira-rest-call. saves LDAP a bunch of work.
 * fixed buggy handling when jira issues disappear. improved unit tests.