### PR TITLE
Add Dynatrace SDK to trace child process activations

### DIFF
--- a/src/SuperDump.DebugDiag/App.config
+++ b/src/SuperDump.DebugDiag/App.config
@@ -1,6 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
-      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/SuperDump.DebugDiag/Options.cs
+++ b/src/SuperDump.DebugDiag/Options.cs
@@ -24,5 +24,8 @@ namespace SuperDump.DebugDiag {
 
 		[Option("analysis", HelpText = "List of DebugDiag analysis rules", Separator = ',')]
 		public IEnumerable<string> AnalysisRules { get; set; }
+
+		[Option("tracetag", HelpText = "dynatrace tracetag", Required = false)]
+		public string TraceTag { get; set; }
 	}
 }

--- a/src/SuperDump.DebugDiag/Program.cs
+++ b/src/SuperDump.DebugDiag/Program.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
 using DebugDiag.DotNet;
+using Dynatrace.OneAgent.Sdk.Api;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,15 +12,17 @@ using System.Threading.Tasks;
 
 namespace SuperDump.DebugDiag {
 	class Program {
+		private static IOneAgentSdk dynatraceSdk = OneAgentSdkFactory.CreateInstance();
 		private static Stopwatch stopwatch = new Stopwatch();
 
 		[STAThread]
 		static void Main(string[] args) {
 			var result = Parser.Default.ParseArguments<Options>(args)
 				.WithParsed(options => {
-					RunAnalysis(options);
+					var tracer = dynatraceSdk.TraceIncomingRemoteCall("Analyze", "SuperDump", "unknownserviceendpoint");
+					tracer.SetDynatraceStringTag(options.TraceTag);
+					tracer.Trace(() => RunAnalysis(options));
 				});
-			
 		}
 
 		private static void PrintError(string msg, params object []args) {

--- a/src/SuperDump.DebugDiag/SuperDump.DebugDiag.csproj
+++ b/src/SuperDump.DebugDiag/SuperDump.DebugDiag.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SuperDump.DebugDiag</RootNamespace>
     <AssemblyName>SuperDump.DebugDiag</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile>
@@ -48,6 +48,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DebugDiag.DotNet">
@@ -80,6 +81,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser">
       <Version>2.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="Dynatrace.OneAgent.Sdk">
+      <Version>1.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/SuperDump/Options.cs
+++ b/src/SuperDump/Options.cs
@@ -12,5 +12,9 @@ namespace SuperDump {
 
 		[Option("out", HelpText = "Output file (json)", Required = true)]
 		public string OutputFile { get; set; }
+
+		[Option("tracetag", HelpText = "dynatrace tracetag", Required = false)]
+		public string TraceTag { get; set; }
+
 	}
 }

--- a/src/SuperDump/Program.cs
+++ b/src/SuperDump/Program.cs
@@ -7,9 +7,12 @@ using SuperDump.Analyzers;
 using SuperDump.Printers;
 using System.Runtime.ExceptionServices;
 using CommandLine;
+using Dynatrace.OneAgent.Sdk.Api;
 
 namespace SuperDump {
 	public static class Program {
+		private static IOneAgentSdk dynatraceSdk = OneAgentSdkFactory.CreateInstance();
+
 		public static string DUMP_LOC;
 		private static string OUTPUT_LOC;
 		public static string SYMBOL_PATH = Environment.GetEnvironmentVariable("_NT_SYMBOL_PATH");
@@ -18,7 +21,9 @@ namespace SuperDump {
 			try {
 				var result = Parser.Default.ParseArguments<Options>(args)
 					.WithParsed(options => {
-						RunAnalysis(options);
+						var tracer = dynatraceSdk.TraceIncomingRemoteCall("Analyze", "SuperDump", "unknownserviceendpoint");
+						tracer.SetDynatraceStringTag(options.TraceTag);
+						tracer.Trace(() => RunAnalysis(options));
 					});
 			} catch (Exception e) {
 				Console.Error.WriteLine($"Exception happened: {e}");

--- a/src/SuperDump/SuperDump.csproj
+++ b/src/SuperDump/SuperDump.csproj
@@ -149,6 +149,9 @@
     <PackageReference Include="CommandLineParser">
       <Version>2.3.0</Version>
     </PackageReference>
+    <PackageReference Include="Dynatrace.OneAgent.Sdk">
+      <Version>1.2.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Runtime">
       <Version>1.0.2</Version>
     </PackageReference>

--- a/src/SuperDumpSelector/App.config
+++ b/src/SuperDumpSelector/App.config
@@ -1,15 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
   <appSettings>
     <!-- dev environment -->
-    <add key="superdumpx86" value="..\..\..\SuperDump\bin\x86\SuperDump.exe"/>
-    <add key="superdumpx64" value="..\..\..\SuperDump\bin\x64\SuperDump.exe"/>
+    <add key="superdumpx86" value="..\..\..\SuperDump\bin\x86\SuperDump.exe" />
+    <add key="superdumpx64" value="..\..\..\SuperDump\bin\x64\SuperDump.exe" />
 
     <!-- deployment environment -->
-    <add key="superdumpx86_deployment" value="..\..\SuperDumpx86\SuperDump.exe"/>
-    <add key="superdumpx64_deployment" value="..\..\SuperDumpx64\SuperDump.exe"/>
+    <add key="superdumpx86_deployment" value="..\..\SuperDumpx86\SuperDump.exe" />
+    <add key="superdumpx64_deployment" value="..\..\SuperDumpx64\SuperDump.exe" />
   </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/SuperDumpSelector/Options.cs
+++ b/src/SuperDumpSelector/Options.cs
@@ -12,5 +12,8 @@ namespace SuperDumpSelector {
 
 		[Option("out", HelpText = "Output file (json)", Required = true)]
 		public string OutputFile { get; set; }
+
+		[Option("tracetag", HelpText = "dynatrace tracetag", Required = false)]
+		public string TraceTag { get; set; }
 	}
 }

--- a/src/SuperDumpSelector/Program.cs
+++ b/src/SuperDumpSelector/Program.cs
@@ -8,14 +8,20 @@ using System.Reflection;
 using System.Threading.Tasks;
 using SuperDump.Common;
 using CommandLine;
+using Dynatrace.OneAgent.Sdk.Api;
+using Dynatrace.OneAgent.Sdk.Api.Enums;
 
 namespace SuperDumpSelector {
 	public static class Program {
+		private static IOneAgentSdk dynatraceSdk = OneAgentSdkFactory.CreateInstance();
+
 		public static int Main(string[] args) {
 			try {
 				var result = Parser.Default.ParseArguments<Options>(args)
 					.WithParsed(options => {
-						RunAnalysis(options);
+						var tracer = dynatraceSdk.TraceIncomingRemoteCall("Analyze", "SuperDumpSelector", "unknownserviceendpoint");
+						tracer.SetDynatraceStringTag(options.TraceTag);
+						tracer.Trace(() => RunAnalysis(options));
 					});
 			} catch (Exception e) {
 				Console.Error.WriteLine($"SuperDumpSelector failed: {e}");
@@ -32,7 +38,7 @@ namespace SuperDumpSelector {
 
 			if (File.Exists(dumpfile)) {
 				var superDumpPathInfo = FindSuperDumpPath(dumpfile);
-				RunSuperDump(superDumpPathInfo, dumpfile, outputfile).Wait();
+				RunSuperDump(superDumpPathInfo, dumpfile, outputfile, options.TraceTag).Wait();
 			} else {
 				throw new FileNotFoundException($"Dump file was not found at {dumpfile}. Please try again");
 			}
@@ -40,7 +46,7 @@ namespace SuperDumpSelector {
 
 		private static FileInfo FindSuperDumpPath(string dumpfile) {
 			using (DataTarget target = DataTarget.LoadCrashDump(dumpfile)) {
-				string superDumpPath; ;
+				string superDumpPath;
 				if (target.PointerSize == 8) {
 					superDumpPath = ResolvePath(ConfigurationManager.AppSettings["superdumpx64"]);
 					if (!File.Exists(superDumpPath)) superDumpPath = ResolvePath(ConfigurationManager.AppSettings["superdumpx64_deployment"]);
@@ -56,20 +62,26 @@ namespace SuperDumpSelector {
 			}
 		}
 
-		private static async Task RunSuperDump(FileInfo superDumpPath, string dumpfile, string outputfile) {
-			string[] arguments = {
-				$"--dump \"{dumpfile}\"",
-				$"--out \"{outputfile}\""
-			};
-			using (var process = await ProcessRunner.Run(superDumpPath.FullName, superDumpPath.Directory, arguments)) {
-				//TrySetPriorityClass(process, ProcessPriorityClass.BelowNormal);
-				Console.WriteLine($"stdout: {process.StdOut}");
-				Console.WriteLine($"stderr: {process.StdErr}");
-				Console.WriteLine($"exitcode: {process.ExitCode}");
-				if (process.ExitCode != 0) {
-					throw new SuperDumpFailedException(process.StdErr);
+		private static async Task RunSuperDump(FileInfo superDumpPath, string dumpfile, string outputfile, string dtTraceTag) {
+			var tracer = dynatraceSdk.TraceOutgoingRemoteCall("Analyze", "SuperDump", "unknownserviceendpoint", ChannelType.OTHER, superDumpPath.FullName);
+			await tracer.TraceAsync(async () => {
+
+				string[] arguments = {
+					$"--dump \"{dumpfile}\"",
+					$"--out \"{outputfile}\"",
+					$"--tracetag \"{tracer.GetDynatraceStringTag()}\""
+				};
+
+				using (var process = await ProcessRunner.Run(superDumpPath.FullName, superDumpPath.Directory, arguments)) {
+					//TrySetPriorityClass(process, ProcessPriorityClass.BelowNormal);
+					Console.WriteLine($"stdout: {process.StdOut}");
+					Console.WriteLine($"stderr: {process.StdErr}");
+					Console.WriteLine($"exitcode: {process.ExitCode}");
+					if (process.ExitCode != 0) {
+						throw new SuperDumpFailedException(process.StdErr);
+					}
 				}
-			}
+			});
 		}
 
 		private static string ResolvePath(string relativePath) {

--- a/src/SuperDumpSelector/SuperDumpSelector.csproj
+++ b/src/SuperDumpSelector/SuperDumpSelector.csproj
@@ -60,7 +60,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -93,6 +92,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser">
       <Version>2.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="Dynatrace.OneAgent.Sdk">
+      <Version>1.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Runtime">
       <Version>1.0.2</Version>

--- a/src/SuperDumpService/SuperDumpService.csproj
+++ b/src/SuperDumpService/SuperDumpService.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-		
+    <PackageReference Include="Dynatrace.OneAgent.Sdk" Version="1.2.0" />
     <PackageReference Include="ByteSize" Version="1.3.0" />
     <PackageReference Include="Hangfire" Version="1.6.21" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.6.21" />


### PR DESCRIPTION
Use the Dynatrace "Remote Call" tracing capability to monitor execution of analysis in child processes. This isn't perfectly "used as intended", but to a wider extent, invoking a child-process and get a result back might be considered a "remote call" :).