### PR TITLE
add check if primary dump is empty to AnalysisService

### DIFF
--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -78,6 +78,11 @@ namespace SuperDumpService.Services {
 			try {
 				dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Analyzing);
 
+				if (new FileInfo(dumpFilePath).Length == 0) {
+					dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Failed, "The primary dump file is empty!");
+					return;
+				}
+
 				if (dumpInfo.DumpType == DumpType.WindowsDump) {
 					await AnalyzeWindows(dumpInfo, new DirectoryInfo(analysisWorkingDir), dumpFilePath);
 				} else if (dumpInfo.DumpType == DumpType.LinuxCoreDump) {


### PR DESCRIPTION
Add a check if the primary dump file is empty before starting the dump analysis to avoid an misleading exception text.