### PR TITLE
Improve IsPrimaryDumpAvailable() Performance

### DIFF
--- a/src/SuperDumpService.Test.Fakes/FakeDumpStorage.cs
+++ b/src/SuperDumpService.Test.Fakes/FakeDumpStorage.cs
@@ -66,12 +66,19 @@ namespace SuperDumpService.Test.Fakes {
 		public string GetDumpFilePath(DumpIdentifier id) {
 			throw new NotImplementedException();
 		}
+		public string GetDumpFilePath(DumpMetainfo dumpInfo) {
+			throw new NotImplementedException();
+		}
 
 		public FileInfo GetFile(DumpIdentifier id, string filename) {
 			throw new NotImplementedException();
 		}
 
 		public IEnumerable<SDFileInfo> GetSDFileInfos(DumpIdentifier id) {
+			throw new NotImplementedException();
+		}
+
+		public IEnumerable<SDFileInfo> GetSDFileInfos(DumpMetainfo dumpInfo) {
 			throw new NotImplementedException();
 		}
 
@@ -124,7 +131,7 @@ namespace SuperDumpService.Test.Fakes {
 			throw new NotImplementedException();
 		}
 
-		public bool ReadIsPrimaryDumpAvailable(DumpIdentifier id) {
+		public bool ReadIsPrimaryDumpAvailable(DumpMetainfo dumpMetainfo) {
 			throw new NotImplementedException();
 		}
 	}

--- a/src/SuperDumpService/Services/DumpRepository.cs
+++ b/src/SuperDumpService/Services/DumpRepository.cs
@@ -94,7 +94,8 @@ namespace SuperDumpService.Services {
 		}
 
 		public void UpdateIsDumpAvailable(DumpIdentifier id) {
-			Get(id).IsPrimaryDumpAvailable = storage.ReadIsPrimaryDumpAvailable(id);
+			DumpMetainfo dumpMetainfo = Get(id);
+			dumpMetainfo.IsPrimaryDumpAvailable = storage.ReadIsPrimaryDumpAvailable(dumpMetainfo);
 		}
 
 		public string GetDumpFilePath(DumpIdentifier id) {

--- a/src/SuperDumpService/Services/IDumpStorage.cs
+++ b/src/SuperDumpService/Services/IDumpStorage.cs
@@ -10,8 +10,10 @@ namespace SuperDumpService.Services {
 		void Create(DumpIdentifier id);
 		void DeleteDumpFile(DumpIdentifier id);
 		string GetDumpFilePath(DumpIdentifier id);
+		string GetDumpFilePath(DumpMetainfo dumpInfo);
 		FileInfo GetFile(DumpIdentifier id, string filename);
 		IEnumerable<SDFileInfo> GetSDFileInfos(DumpIdentifier id);
+		IEnumerable<SDFileInfo> GetSDFileInfos(DumpMetainfo dumpInfo);
 		bool MiniInfoExists(DumpIdentifier id);
 		Task<IEnumerable<DumpMetainfo>> ReadDumpMetainfoForBundle(string bundleId);
 		Task<DumpMiniInfo> ReadMiniInfo(DumpIdentifier id);
@@ -20,6 +22,6 @@ namespace SuperDumpService.Services {
 		void Store(DumpMetainfo dumpInfo);
 		Task StoreMiniInfo(DumpIdentifier id, DumpMiniInfo miniInfo);
 		void WriteResult(DumpIdentifier id, SDResult result);
-		bool ReadIsPrimaryDumpAvailable(DumpIdentifier id);
+		bool ReadIsPrimaryDumpAvailable(DumpMetainfo dumpMetainfo);
 	}
 }


### PR DESCRIPTION
fix bug that the DumpMetainfo file is read multiple times during the repository population