### PR TITLE
Fix Jira issue refresh

### DIFF
--- a/src/SuperDumpService/Models/JiraIssueModel.cs
+++ b/src/SuperDumpService/Models/JiraIssueModel.cs
@@ -38,6 +38,16 @@ namespace SuperDumpService.Models {
 			public string Id { get; set; }
 		}
 
+		public class KeyEqualityComparer : IEqualityComparer<JiraIssueModel> {
+			public bool Equals(JiraIssueModel x, JiraIssueModel y) {
+				return x.Key.Equals(y.Key);
+			}
+
+			public int GetHashCode(JiraIssueModel obj) {
+				return obj.Key.GetHashCode();
+			}
+		}
+
 		public override string ToString() {
 			return Key;
 		}

--- a/src/SuperDumpService/Models/JiraIssueModel.cs
+++ b/src/SuperDumpService/Models/JiraIssueModel.cs
@@ -15,6 +15,15 @@ namespace SuperDumpService.Models {
 			this.Key = key;
 		}
 
+		public JiraIssueModel(string key, string status) {
+			this.Key = key;
+			this.Fields = new JiraIssueFieldModel {
+				Status = new JiraIssueStatusModel {
+					Name = status
+				}
+			};
+		}
+
 		public string GetStatusName() {
 			return Fields != null && Fields.Status != null ? Fields.Status.Name : null;
 		}

--- a/src/SuperDumpService/Services/JiraIssueRepository.cs
+++ b/src/SuperDumpService/Services/JiraIssueRepository.cs
@@ -121,8 +121,8 @@ namespace SuperDumpService.Services {
 					ToLookup(issue => issue.GetStatusName() != "Resolved");
 
 				//Get the current status of not resolved issues from the jira api and combine them with the resolved issues
-				IEnumerable<JiraIssueModel> refreshedIssues = issuesToRefresh[false]
-						.Union(await apiService.GetBulkIssues(issuesToRefresh[true].Select(i => i.Key)));
+				IEnumerable<JiraIssueModel> refreshedIssues = (await apiService.GetBulkIssues(issuesToRefresh[true].Select(i => i.Key)))
+						.Union(issuesToRefresh[false], new JiraIssueModel.KeyEqualityComparer());
 
 				await SetBundleIssues(bundlesToRefresh, refreshedIssues);
 			} finally {

--- a/src/SuperDumpService/Services/JiraIssueRepository.cs
+++ b/src/SuperDumpService/Services/JiraIssueRepository.cs
@@ -110,7 +110,7 @@ namespace SuperDumpService.Services {
 			try {
 				//Only update bundles with unresolved issues
 				IEnumerable<KeyValuePair<string, IList<JiraIssueModel>>> bundlesToRefresh =
-					bundleIssues.Where(bundle => bundle.Value.Any(issue => issue.GetStatusName() != "Resolved"));
+					bundleIssues.Where(bundle => bundle.Value.Any(issue => !issue.IsResolved()));
 
 				if (!bundlesToRefresh.Any()) {
 					return;
@@ -118,7 +118,7 @@ namespace SuperDumpService.Services {
 
 				//Split issues into one group with all resolved issues and one with all others
 				ILookup<bool, JiraIssueModel> issuesToRefresh = bundlesToRefresh.SelectMany(issue => issue.Value).
-					ToLookup(issue => issue.GetStatusName() != "Resolved");
+					ToLookup(issue => !issue.IsResolved());
 
 				//Get the current status of not resolved issues from the jira api and combine them with the resolved issues
 				IEnumerable<JiraIssueModel> refreshedIssues = (await apiService.GetBulkIssues(issuesToRefresh[true].Select(i => i.Key)))

--- a/src/SuperDumpService/Services/JiraIssueRepository.cs
+++ b/src/SuperDumpService/Services/JiraIssueRepository.cs
@@ -206,10 +206,8 @@ namespace SuperDumpService.Services {
 			//I am not sure if this is the best way to do this
 			var fileStorageTasks = new List<Task>();
 			foreach (KeyValuePair<string, IList<JiraIssueModel>> bundle in bundlesToUpdate) {
-				if (issueDictionary.ContainsKey(bundle.Key)) {
-					IList<JiraIssueModel> issues = bundle.Value.Select(issue => issueDictionary[issue.Key]).ToList();
-					fileStorageTasks.Add(jiraIssueStorage.Store(bundle.Key, bundleIssues[bundle.Key] = issues)); //update the issue file for the bundle
-				}
+				IList<JiraIssueModel> issues = bundle.Value.Select(issue => issueDictionary[issue.Key]).ToList();
+				fileStorageTasks.Add(jiraIssueStorage.Store(bundle.Key, bundleIssues[bundle.Key] = issues)); //update the issue file for the bundle
 			}
 
 			await Task.WhenAll(fileStorageTasks);


### PR DESCRIPTION
* Fixed a bug that would prevent the cached Jira issues from being updated if one issue references multiple bundles.

* Added an unit test for the Jira issue refresh method.