### PR TITLE
fix svn source links

### DIFF
--- a/src/SuperDump.Common/DynatraceSourceLink.cs
+++ b/src/SuperDump.Common/DynatraceSourceLink.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace SuperDump.Common {
 	public class DynatraceSourceLink {
-		private static readonly Regex SprintPathRegex = new Regex(@"^.*\\oa-s(\d*)\\[^\\]*\\(.*)$");
+		private static readonly Regex SprintPathRegex = new Regex(@"^.*(?:\\|/)oa-s(\d*)(?:\\|/)[^\\/]*(?:\\|/)(.*)$");
 
 		public static string GetRepoPathIfAvailable(string sourcePath) {
 			Match match;

--- a/src/SuperDump.Common/DynatraceSourceLink.cs
+++ b/src/SuperDump.Common/DynatraceSourceLink.cs
@@ -1,13 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace SuperDump.Common {
 	public class DynatraceSourceLink {
+		private static readonly Regex SprintPathRegex = new Regex(@"^.*\\oa-s(\d*)\\[^\\]*\\(.*)$");
+
 		public static string GetRepoPathIfAvailable(string sourcePath) {
+			Match match;
 			if (sourcePath.Contains("sprint_")) {
 				int sprintOffset = sourcePath.IndexOf("sprint_");
 				return "branches/" + sourcePath.Substring(sprintOffset);
+			} else if ((match = SprintPathRegex.Match(sourcePath)).Success) {
+				return $"branches/sprint_{match.Groups[1]}/{match.Groups[2]}";
 			} else if (sourcePath.Contains("trunk")) {
 				int trunkOffset = sourcePath.IndexOf("trunk");
 				return sourcePath.Substring(trunkOffset);

--- a/src/SuperDumpService.Test/SvnLinkParserTests.cs
+++ b/src/SuperDumpService.Test/SvnLinkParserTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using SuperDump.Common;
+using Xunit;
+
+namespace SuperDumpService.Test {
+	public class SvnLinkParserTests {
+		[Fact]
+		public void TestSvnLinkParser() {
+			string inputLinux = "/path/to/src/oa-s160/linux-x86/src/folder/test.c:30";
+			string expectedLinux = "branches/sprint_160/src/folder/test.c:30";
+			Assert.Equal(expectedLinux, DynatraceSourceLink.GetRepoPathIfAvailable(inputLinux));
+
+			string inputWindows = @"c:\path\to\src\oa-s160\linux-x86\src\folder\test.c:30";
+			string expectedWindows = @"branches/sprint_160/src\folder\test.c:30";
+			Assert.Equal(expectedWindows, DynatraceSourceLink.GetRepoPathIfAvailable(inputWindows));
+
+			string inputTrunk = @"c:\path\to\src\trunk\src\folder\test.c:30";
+			string expectedTrunk = @"trunk\src\folder\test.c:30";
+			Assert.Equal(expectedTrunk, DynatraceSourceLink.GetRepoPathIfAvailable(inputTrunk));
+
+			string inputSprint = @"c:\path\to\src\sprint_160\src\folder\test.c:30";
+			string expectedSprint = @"branches/sprint_160\src\folder\test.c:30";
+			Assert.Equal(expectedSprint, DynatraceSourceLink.GetRepoPathIfAvailable(inputSprint));
+
+			string inputInvalid = @"c:\path\to\src\folder\test.c:30";
+			Assert.Null(DynatraceSourceLink.GetRepoPathIfAvailable(inputInvalid));
+		}
+	}
+}


### PR DESCRIPTION
Added handling for another source path format.

However, the source links are still not working since we do not have information about the correct case of the filename.