### PR TITLE
Add elf header analyzer

### DIFF
--- a/src/SuperDump.Analyzer.Linux/Analysis/CoreDumpAnalyzer.cs
+++ b/src/SuperDump.Analyzer.Linux/Analysis/CoreDumpAnalyzer.cs
@@ -130,6 +130,8 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 			new DebugSymbolResolver(filesystem, requestHandler, processHandler).Resolve(analysisResult.SystemContext.Modules);
 			Console.WriteLine("Unwinding stacktraces ...");
 			new UnwindAnalyzer(coredump, analysisResult).Analyze();
+			Console.WriteLine("Parsing ELF Header Info ...");
+			await new ElfHeaderAnalyzer(coredump, analysisResult).Analyze();
 			Console.WriteLine("Retrieving agent version if available ...");
 			new CoreLogAnalyzer(filesystem, coredump, analysisResult.SystemContext.Modules).Analyze();
 			Console.WriteLine("Fetching debug symbols ...");

--- a/src/SuperDump.Analyzer.Linux/Analysis/ElfHeaderAnalyzer.cs
+++ b/src/SuperDump.Analyzer.Linux/Analysis/ElfHeaderAnalyzer.cs
@@ -46,7 +46,7 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 				return "Amd64";
 			}
 
-			return architecture;
+			return architecture + " (Unsupported)";
 		}
 	}
 }

--- a/src/SuperDump.Analyzer.Linux/Analysis/ElfHeaderAnalyzer.cs
+++ b/src/SuperDump.Analyzer.Linux/Analysis/ElfHeaderAnalyzer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using SuperDump.Analyzer.Linux.Boundary;
+using SuperDump.Common;
+using Thinktecture.IO;
+
+namespace SuperDump.Analyzer.Linux.Analysis {
+	class ElfHeaderAnalyzer {
+		private static readonly Regex ArchitectureRegex = new Regex("^\\s*Machine:\\s*(.*)$", RegexOptions.Multiline);
+
+		private readonly IFileInfo coredump;
+		private readonly Models.SDResult analysisResult;
+
+		public ElfHeaderAnalyzer(IFileInfo coredump, Models.SDResult analysisResult) {
+			this.coredump = coredump ?? throw new ArgumentNullException("Coredump must not be null!");
+			this.analysisResult = analysisResult ?? throw new ArgumentNullException("Analysis result must not be null!");
+		}
+
+		public async Task Analyze() {
+			using (ProcessRunner proc = await ProcessRunner.Run("readelf", new DirectoryInfo(Directory.GetCurrentDirectory()), "-h " + coredump.FullName)) {
+				if (proc.ExitCode != 0) {
+					Console.WriteLine($"readelf -h exited with error: {proc.StdErr}");
+				}
+
+				Match match = ArchitectureRegex.Match(proc.StdOut);
+				if (match.Success) {
+					 analysisResult.SystemContext.SystemArchitecture = match.Groups[1].Value;
+				}
+			}
+		}
+	}
+}

--- a/src/SuperDump.Analyzer.Linux/Analysis/ElfHeaderAnalyzer.cs
+++ b/src/SuperDump.Analyzer.Linux/Analysis/ElfHeaderAnalyzer.cs
@@ -10,7 +10,7 @@ using Thinktecture.IO;
 
 namespace SuperDump.Analyzer.Linux.Analysis {
 	class ElfHeaderAnalyzer {
-		private static readonly Regex ArchitectureRegex = new Regex("^\\s*Machine:\\s*(.*)$", RegexOptions.Multiline);
+		private static readonly Regex ArchitectureRegex = new Regex("^\\s*Machine:\\s*(.+)$", RegexOptions.Multiline);
 
 		private readonly IFileInfo coredump;
 		private readonly Models.SDResult analysisResult;
@@ -20,6 +20,10 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 			this.analysisResult = analysisResult ?? throw new ArgumentNullException("Analysis result must not be null!");
 		}
 
+		/// <summary>
+		/// Sets the system architecture to the "Machine" field of the ELF header, as returned by readelf -h.
+		/// </summary>
+		/// <returns></returns>
 		public async Task Analyze() {
 			using (ProcessRunner proc = await ProcessRunner.Run("readelf", new DirectoryInfo(Directory.GetCurrentDirectory()), "-h " + coredump.FullName)) {
 				if (proc.ExitCode != 0) {
@@ -28,9 +32,21 @@ namespace SuperDump.Analyzer.Linux.Analysis {
 
 				Match match = ArchitectureRegex.Match(proc.StdOut);
 				if (match.Success) {
-					 analysisResult.SystemContext.SystemArchitecture = match.Groups[1].Value;
+					analysisResult.SystemContext.SystemArchitecture = MapArchitectureDescription(match.Groups[1].Value);
 				}
 			}
+		}
+
+		private string MapArchitectureDescription(string architecture) {
+			if (architecture == "Intel 80386") {
+				return "x86";
+			}
+
+			if (architecture == "Advanced Micro Devices X86-64") {
+				return "Amd64";
+			}
+
+			return architecture;
 		}
 	}
 }


### PR DESCRIPTION
The linux dump analysis now parses the header information from readelf for better system architecture detection.