### PR TITLE
add retry for dump downloads using the DownloadService

### DIFF
--- a/conf/appsettings.json.template
+++ b/conf/appsettings.json.template
@@ -127,5 +127,7 @@
       "JiraDumpRetentionTimeExtensionDays": "7"
     },
     "DuplicationDetectionEnabled": "true" // if enabled, the same bundle (md5 hash check) does not get analyzed twice
+    "DownloadServiceRetry": "5", // Number of retries when trying to download a dump file from an URL
+    "DownloadServiceRetryTimeout": "500" //Time between download retries in milliseconds
   }
 }

--- a/src/SuperDumpService/SuperDumpService.csproj
+++ b/src/SuperDumpService/SuperDumpService.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview6.19307.2" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.0.0-preview6.19304.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0-preview6.19304.6" /><!-- required since the update to .net core 3.0 because of a missing dependency -->
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.0.0-preview6.19304.6" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="ByteSize" Version="2.0.0-alpha2" />
     <PackageReference Include="Hangfire" Version="1.7.3" />

--- a/src/SuperDumpService/SuperDumpSettings.cs
+++ b/src/SuperDumpService/SuperDumpSettings.cs
@@ -40,6 +40,8 @@ namespace SuperDumpService {
 		public JiraIntegrationSettings JiraIntegrationSettings { get; set; }
 		public bool UseAllRequestLogging { get; set; }
 		public bool DuplicationDetectionEnabled { get; set; }
+		public int DownloadServiceRetry { get; set; } = 3;
+		public int DownloadServiceRetryTimeout { get; set; } = 500;
 
         public bool IsDumpRetentionEnabled () {
 			return !string.IsNullOrEmpty(DumpRetentionCron) && DumpRetentionDays > 0;


### PR DESCRIPTION
The dump Download from an URL fails sometimes. Now the Download is attempted multiple times if it fails. The maximum number of retry attempts can be configured in the appsettings.json file.