### PR TITLE
increase timeout of HttpClient

### DIFF
--- a/conf/appsettings.json.template
+++ b/conf/appsettings.json.template
@@ -126,9 +126,9 @@
 
       "JiraDumpRetentionTimeExtensionDays": "7"
     },
-    "DuplicationDetectionEnabled": "true" // if enabled, the same bundle (md5 hash check) does not get analyzed twice
+    "DuplicationDetectionEnabled": "true", // if enabled, the same bundle (md5 hash check) does not get analyzed twice
     "DownloadServiceRetry": "5", // Number of retries when trying to download a dump file from an URL
-    "DownloadServiceRetryTimeout": "500" //Time between download retries in milliseconds
-    "DownloadServiceHttpClientTimeout": 4 //HttpClient timeout in minutes
+    "DownloadServiceRetryTimeout": "500", //Time between download retries in milliseconds
+    "DownloadServiceHttpClientTimeout": "00:04:00"
   }
 }

--- a/conf/appsettings.json.template
+++ b/conf/appsettings.json.template
@@ -129,5 +129,6 @@
     "DuplicationDetectionEnabled": "true" // if enabled, the same bundle (md5 hash check) does not get analyzed twice
     "DownloadServiceRetry": "5", // Number of retries when trying to download a dump file from an URL
     "DownloadServiceRetryTimeout": "500" //Time between download retries in milliseconds
+    "DownloadServiceHttpClientTimeout": 4 //HttpClient timeout in minutes
   }
 }

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -131,7 +131,7 @@ namespace SuperDumpService {
 			});
 
 			// Add HttpErrorPolicy for ObjectDisposedException when downloading a dump file using the DownloadService
-			services.AddHttpClient(DownloadService.HttpClientName, config => config.Timeout = TimeSpan.FromMinutes(superDumpSettings.DownloadServiceHttpClientTimeout))
+			services.AddHttpClient(DownloadService.HttpClientName, config => config.Timeout = superDumpSettings.DownloadServiceHttpClientTimeout)
 				.AddTransientHttpErrorPolicy(builder => builder
 					.OrInner<ObjectDisposedException>()
 					.WaitAndRetryAsync(superDumpSettings.DownloadServiceRetry,

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -131,10 +131,11 @@ namespace SuperDumpService {
 			});
 
 			// Add HttpErrorPolicy for ObjectDisposedException when downloading a dump file using the DownloadService
-			services.AddHttpClient(DownloadService.HttpClientName).AddTransientHttpErrorPolicy(builder => builder
-				.OrInner<ObjectDisposedException>()
-				.WaitAndRetryAsync(superDumpSettings.DownloadServiceRetry,
-					_ => TimeSpan.FromMilliseconds(superDumpSettings.DownloadServiceRetryTimeout)));
+			services.AddHttpClient(DownloadService.HttpClientName, config => config.Timeout = TimeSpan.FromMinutes(superDumpSettings.DownloadServiceHttpClientTimeout))
+				.AddTransientHttpErrorPolicy(builder => builder
+					.OrInner<ObjectDisposedException>()
+					.WaitAndRetryAsync(superDumpSettings.DownloadServiceRetry,
+						_ => TimeSpan.FromMilliseconds(superDumpSettings.DownloadServiceRetryTimeout)));
 
 			// register repository as singleton
 			services.AddSingleton<SuperDumpRepository>();

--- a/src/SuperDumpService/SuperDumpSettings.cs
+++ b/src/SuperDumpService/SuperDumpSettings.cs
@@ -42,7 +42,7 @@ namespace SuperDumpService {
 		public bool DuplicationDetectionEnabled { get; set; }
 		public int DownloadServiceRetry { get; set; } = 3;
 		public int DownloadServiceRetryTimeout { get; set; } = 500;
-		public double DownloadServiceHttpClientTimeout { get; set; } = 5;
+		public TimeSpan DownloadServiceHttpClientTimeout { get; set; } = TimeSpan.FromMinutes(4);
 
 		public bool IsDumpRetentionEnabled () {
 			return !string.IsNullOrEmpty(DumpRetentionCron) && DumpRetentionDays > 0;

--- a/src/SuperDumpService/SuperDumpSettings.cs
+++ b/src/SuperDumpService/SuperDumpSettings.cs
@@ -42,8 +42,9 @@ namespace SuperDumpService {
 		public bool DuplicationDetectionEnabled { get; set; }
 		public int DownloadServiceRetry { get; set; } = 3;
 		public int DownloadServiceRetryTimeout { get; set; } = 500;
+		public double DownloadServiceHttpClientTimeout { get; set; } = 5;
 
-        public bool IsDumpRetentionEnabled () {
+		public bool IsDumpRetentionEnabled () {
 			return !string.IsNullOrEmpty(DumpRetentionCron) && DumpRetentionDays > 0;
 		}
 	}


### PR DESCRIPTION
The default timeout of the HttpClient is 100 seconds. It is possible that this is not sufficient for larger dump files.
I added a field for the timeout to the appsettings and increased the default to 4 minutes.