### PR TITLE
fix rerun analysis and analysis pipeline state

### DIFF
--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -82,7 +82,7 @@ namespace SuperDumpService.Services {
 		public async Task AnalyzeAsync(DumpMetainfo dumpInfo, string analysisWorkingDir) {
 			await bundleRepo.BlockIfBundleRepoNotReady($"AnalysisService.Analyze for {dumpInfo.Id}");
 
-			dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Analyzing);
+			dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Analyzing, string.Empty);
 
 			AnalyzerState state = AnalyzerState.Initialized;
 			foreach (AnalyzerJob analyzerJob in analyzerPipeline.Analyzers) {

--- a/src/SuperDumpService/Services/Analyzers/DumpAnalyzerJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/DumpAnalyzerJob.cs
@@ -44,7 +44,7 @@ namespace SuperDumpService.Services.Analyzers {
 
 		public override async Task<AnalyzerState> AnalyzeDump(DumpMetainfo dumpInfo, string analysisWorkingDir, AnalyzerState previousState) {
 			if (dumpInfo.DumpType != DumpType.WindowsDump && dumpInfo.DumpType != DumpType.LinuxCoreDump) {
-				return AnalyzerState.Failed;
+				return previousState;
 			}
 
 			try {

--- a/src/SuperDumpService/Services/Analyzers/ElasticSearchJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/ElasticSearchJob.cs
@@ -16,7 +16,7 @@ namespace SuperDumpService.Services.Analyzers {
 		}
 
 		public override async Task<AnalyzerState> AnalyzeDump(DumpMetainfo dumpInfo, string analysisWorkingDir, AnalyzerState previousState) {
-			if (previousState == AnalyzerState.Failed) {
+			if (previousState != AnalyzerState.Succeeded) {
 				return previousState;
 			}
 

--- a/src/SuperDumpService/Services/DumpRepository.cs
+++ b/src/SuperDumpService/Services/DumpRepository.cs
@@ -68,10 +68,6 @@ namespace SuperDumpService.Services {
 		/// Does NOT start analysis
 		/// </summary>
 		/// <returns></returns>
-		public async Task<DumpMetainfo> CreateDump(string bundleId, FileInfo sourcePath) {
-			return await CreateDump(bundleId, sourcePath, DetermineDumpType(sourcePath));
-		}
-
 		public async Task<DumpMetainfo> CreateDump(string bundleId, FileInfo sourcePath, DumpType dumpType) {
 			DumpMetainfo dumpInfo = CreateDumpMetainfo(bundleId);
 
@@ -122,13 +118,10 @@ namespace SuperDumpService.Services {
 		}
 
 		public void ResetDumpTyp(DumpIdentifier id) {
-			SetDumpType(id, DetermineDumpType(new FileInfo(Get(id).DumpFileName)));
-		}
-
-		private DumpType DetermineDumpType(FileInfo sourcePath) {
-			if (sourcePath.Name.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase)) return DumpType.WindowsDump;
-			if (sourcePath.Name.EndsWith(".core.gz", StringComparison.OrdinalIgnoreCase)) return DumpType.LinuxCoreDump;
-			throw new InvalidDataException($"cannot determine dumptype of {sourcePath.FullName}");
+			string filename = Get(id).DumpFileName;
+			if (filename.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase)) SetDumpType(id, DumpType.WindowsDump);
+			if (filename.EndsWith(".core.gz", StringComparison.OrdinalIgnoreCase)) SetDumpType(id, DumpType.LinuxCoreDump);
+			if (filename.EndsWith(".core", StringComparison.OrdinalIgnoreCase)) SetDumpType(id, DumpType.LinuxCoreDump);
 		}
 
 		public void DeleteDumpFile(DumpIdentifier id) {

--- a/src/SuperDumpService/Views/Home/_System.cshtml
+++ b/src/SuperDumpService/Views/Home/_System.cshtml
@@ -47,10 +47,11 @@
 					<dt class="col-sm-3 text-right"># of logical processors:</dt>
 					<dd class="col-sm-9">@Model.Result.SystemContext.NumberOfProcessors</dd>
 				}
-
-				@foreach (var clr in Model.Result.SystemContext.ClrVersions) {
-					<dt class="col-sm-3 text-right">.NET CLR:</dt>
-					<dd class="col-sm-9">@clr.Version (@clr.ClrFlavor)</dd>
+				@if (Model.Result.SystemContext.ClrVersions != null) {
+					@foreach (var clr in Model.Result.SystemContext.ClrVersions) {
+						<dt class="col-sm-3 text-right">.NET CLR:</dt>
+						<dd class="col-sm-9">@clr.Version (@clr.ClrFlavor)</dd>
+					}
 				}
 			</dl>
 			<dl class="row courier-small compact">


### PR DESCRIPTION
Fixed that the error message was not reset when rerunning an analysis.

Now the Dump Analyzer does not change the pipeline state to failed if the dump is not a Linux or Windows dump since it does nothing in that case.
The Elastic Search Analyzer now only starts if the previous state is succeeded.