### PR TITLE
Add amazon sqs support

### DIFF
--- a/conf/appsettings.json.template
+++ b/conf/appsettings.json.template
@@ -129,6 +129,18 @@
     "DuplicationDetectionEnabled": "true", // if enabled, the same bundle (md5 hash check) does not get analyzed twice
     "DownloadServiceRetry": "5", // Number of retries when trying to download a dump file from an URL
     "DownloadServiceRetryTimeout": "500", //Time between download retries in milliseconds
-    "DownloadServiceHttpClientTimeout": "00:04:00"
+    "DownloadServiceHttpClientTimeout": "00:04:00",
+    "UseAmazonSqs": "true",
+    "AmazonSqsSettings": {
+      "SuperDumpBaseUrl": "", // Url that is used for generating the response messages
+      "PollCron": "*/30 * * * *", //Hangfire cron expression which describes the schedule for polling the Aws Queue
+      "MessagesPerReceive": 10, // The maximum number of messages per receive message batch. This is limited to 10 by Amazon (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html#quotas-messages).
+      "MessageVisibilityTimeout": "00:00:30", //The time in which received messages remain locked as Timespan.
+      "Region": "", //The AWS region used e.g. "us-west-1"
+      "InputQueueUrl": "", //The url of the queue where superdump should check for new dumps
+      "OutputQueueUrl": "", //The url of the queue where superdump should push the results
+      "AccessKey": "",
+      "SecretKey": ""
+    }
   }
 }

--- a/src/SuperDumpService/AmazonSqsSettings.cs
+++ b/src/SuperDumpService/AmazonSqsSettings.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SuperDumpService {
+	public class AmazonSqsSettings {
+		public string SuperDumpBaseUrl { get; set; }
+		public string PollCron { get; set; }
+		public int MessagesPerReceive { get; set; } = 10;
+		public TimeSpan MessageVisibilityTimeout { get; set; }
+		public string Region { get; set; }
+		public string InputQueueUrl { get; set; }
+		public string OutputQueueUrl { get; set; }
+		public string AccessKey { get; set; }
+		public string SecretKey { get; set; }
+	}
+}

--- a/src/SuperDumpService/Controllers/api/DumpsController.cs
+++ b/src/SuperDumpService/Controllers/api/DumpsController.cs
@@ -84,21 +84,11 @@ namespace SuperDumpService.Controllers.Api {
 		public IActionResult Post([FromBody]DumpAnalysisInput input) {
 			if (ModelState.IsValid) {
 
-				string filename = input.UrlFilename;
+				string bundleId = superDumpRepo.ProcessWebInputfile(input);
 				//validate URL
-				if (Utility.ValidateUrl(input.Url, ref filename)) {
-					if (filename == null && Utility.IsLocalFile(input.Url)) {
-						filename = Path.GetFileName(input.Url);
-					}
-					string bundleId = superDumpRepo.ProcessWebInputfile(filename, input);
-					if (bundleId != null) {
-						logger.LogFileUpload("Api Upload", HttpContext, bundleId, input.CustomProperties, input.Url);
-						return CreatedAtAction(nameof(HomeController.BundleCreated), "Home", new { bundleId = bundleId }, null);
-					} else {
-						// in case the input was just symbol files, we don't get a bundleid.
-						// TODO
-						throw new NotImplementedException();
-					}
+				if (!string.IsNullOrEmpty(bundleId)) {
+					logger.LogFileUpload("Api Upload", HttpContext, bundleId, input.CustomProperties, input.Url);
+					return CreatedAtAction(nameof(HomeController.BundleCreated), "Home", new { bundleId = bundleId }, null);
 				} else {
 					logger.LogNotFound("Api Upload: File not found", HttpContext, "Url", input.Url);
 					return BadRequest("Invalid request, resource identifier is not valid or cannot be reached.");

--- a/src/SuperDumpService/Helpers/SuperDumpLogExtension.cs
+++ b/src/SuperDumpService/Helpers/SuperDumpLogExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -88,6 +89,10 @@ namespace SuperDumpService.Helpers {
 		}
 		public static void LogSqsInvalidUrl(this ILogger logger, AwsDumpAnalysisInput dumpInput) {
 			logger.LogInformation(AwsInvalidUrlText, GetCustomPropertyString(dumpInput.CustomProperties), dumpInput.Url, dumpInput.SourceId);
+		}
+
+		public static void LogSqsException(this ILogger logger, string messageBody, Exception ex) {
+			logger.LogInformation($"Exception while processing Amazon Sqs Message - Message: \"{messageBody}\" Exception: {ex.ToString()}");
 		}
 
 		private static string GetCustomPropertyString(IDictionary<string, string> customProperties) {

--- a/src/SuperDumpService/Helpers/SuperDumpLogExtension.cs
+++ b/src/SuperDumpService/Helpers/SuperDumpLogExtension.cs
@@ -18,6 +18,8 @@ namespace SuperDumpService.Helpers {
 		private const string AccessDeniedText = DefaultLogText + ", Url: {Url}";
 		private const string RequestLogText = "Ip: {Ip}, User: {User}, Action: {action}, Path: {path}, Parameters: {params}";
 		private const string DumpComparisonText = DefaultLogText + ", BundleId1: {BundleId1}, DumpId1: {DumpId1}, BundleId1: {BundleId1}, DumpId1: {DumpId1}";
+		private const string AwsFileText = "File Url received from Amazon SQS, BundleId: {BundleId}, {customProperties}, Url: {Url}, SourceId: {SourceId}";
+		private const string AwsInvalidUrlText = "Invalid file Url received from Amazon SQS, {customProperties}, Url: {Url}, SourceId: {SourceId}";
 
 		public static void LogDumpAccess(this ILogger logger, string text, HttpContext context, BundleMetainfo bundleInfo, string dumpId) {
 			logger.LogInformation(DumpLogText, text, context.Connection.RemoteIpAddress.ToString(), context.User.Identity.Name,
@@ -79,6 +81,13 @@ namespace SuperDumpService.Helpers {
 		}
 		public static void LogSimilarityEvent(this ILogger logger, string text, HttpContext context, string bundleId1, string dumpId1, string bundleId2, string dumpId2) {
 			logger.LogInformation(DumpComparisonText, text, context.Connection.RemoteIpAddress.ToString(), context.User.Identity.Name, bundleId1, dumpId1, bundleId2, dumpId2);
+		}
+
+		public static void LogSqsFileUpload(this ILogger logger, string bundleId, AwsDumpAnalysisInput dumpInput) {
+			logger.LogInformation(AwsFileText, bundleId, GetCustomPropertyString(dumpInput.CustomProperties), dumpInput.Url, dumpInput.SourceId);
+		}
+		public static void LogSqsInvalidUrl(this ILogger logger, AwsDumpAnalysisInput dumpInput) {
+			logger.LogInformation(AwsInvalidUrlText, GetCustomPropertyString(dumpInput.CustomProperties), dumpInput.Url, dumpInput.SourceId);
 		}
 
 		private static string GetCustomPropertyString(IDictionary<string, string> customProperties) {

--- a/src/SuperDumpService/Models/DumpAnalysisResponse.cs
+++ b/src/SuperDumpService/Models/DumpAnalysisResponse.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SuperDumpService.Models {
+	public class DumpAnalysisResponse {
+		public string SourceId { get; }
+		public string SuperdumpUrl { get; }
+
+		public DumpAnalysisResponse(string sourceId, string superDumpUrl) {
+			SourceId = sourceId;
+			SuperdumpUrl = superDumpUrl;
+		}
+	}
+}

--- a/src/SuperDumpService/Models/InputModel.cs
+++ b/src/SuperDumpService/Models/InputModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace SuperDumpService.Controllers {
+namespace SuperDumpService.Models {
 	public class DumpAnalysisInput {
 
 		public DumpAnalysisInput() {
@@ -39,5 +39,12 @@ namespace SuperDumpService.Controllers {
 
 		// for compat. use CustomProperties instead!
 		public string FriendlyName { get; set; }
+	}
+
+	public class AwsDumpAnalysisInput : DumpAnalysisInput {
+		/// <summary>
+		/// This Id is used to correlate the dump input with the response that the dump was created.
+		/// </summary>
+		public string SourceId { get; set; }
 	}
 }

--- a/src/SuperDumpService/Services/AmazonSqsService.cs
+++ b/src/SuperDumpService/Services/AmazonSqsService.cs
@@ -90,6 +90,7 @@ namespace SuperDumpService.Services {
 					result = ProcessMessage(message);
 				} catch (Exception e) {
 					Console.WriteLine(e);
+					logger.LogSqsException(message.Body, e);
 				}
 
 				if (result != null) {

--- a/src/SuperDumpService/Services/AmazonSqsService.cs
+++ b/src/SuperDumpService/Services/AmazonSqsService.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Hangfire;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using SuperDumpService.Controllers;
+using SuperDumpService.Helpers;
+using SuperDumpService.Models;
+
+namespace SuperDumpService.Services {
+	public class AmazonSqsService {
+		private readonly AmazonSqsSettings amazonSqsSettings;
+		private readonly IAmazonSQS sqsClient;
+		private readonly SuperDumpRepository superDumpRepo;
+		private readonly LinkGenerator linkGenerator;
+		private readonly ILogger<AmazonSqsService> logger;
+		private readonly Uri baseUri;
+
+		public AmazonSqsService(IOptions<SuperDumpSettings> settings, SuperDumpRepository superDumpRepo, LinkGenerator linkGenerator, ILoggerFactory loggerFactory) {
+			this.amazonSqsSettings = settings.Value.AmazonSqsSettings;
+			this.superDumpRepo = superDumpRepo;
+			this.linkGenerator = linkGenerator;
+
+			this.logger = loggerFactory.CreateLogger<AmazonSqsService>();
+
+			var credentials = new BasicAWSCredentials(amazonSqsSettings.AccessKey, amazonSqsSettings.SecretKey);
+			var config = new AmazonSQSConfig {
+				RegionEndpoint = RegionEndpoint.GetBySystemName(amazonSqsSettings.Region)
+			};
+			this.sqsClient = new AmazonSQSClient(credentials, config);
+
+			this.baseUri = new Uri(amazonSqsSettings.SuperDumpBaseUrl);
+		}
+
+
+		public void StartHangfireJob() {
+			RecurringJob.AddOrUpdate(() => PollQueue(), amazonSqsSettings.PollCron);
+		}
+
+		[Queue("amazon-sqs-poll")]
+		public void PollQueue() {
+			AsyncHelper.RunSync(PollQueueAsync);
+		}
+
+		public async Task PollQueueAsync() {
+			var request = new ReceiveMessageRequest(amazonSqsSettings.InputQueueUrl) {
+				MaxNumberOfMessages = amazonSqsSettings.MessagesPerReceive,
+				VisibilityTimeout = (int)amazonSqsSettings.MessageVisibilityTimeout.TotalSeconds
+			};
+
+			int received;
+
+			do {
+				ReceiveMessageResponse response = await sqsClient.ReceiveMessageAsync(request);
+
+				received = response.Messages.Count;
+
+				if (received > 0) {
+					await ProcessMessageBatch(response.Messages);
+				}
+			} while (received >= amazonSqsSettings.MessagesPerReceive);
+		}
+
+		/// <summary>
+		/// Processes a message batch, sends response messages and deletes all handled messages.
+		/// 
+		/// Received messages are deleted from the queue even if an error occurs while handling them.
+		/// This is to avoid filling the queue with invalid messages.
+		/// </summary>
+		/// <param name="messages"></param>
+		/// <returns></returns>
+		private async Task ProcessMessageBatch(List<Message> messages) {
+			var deleteEntries = new List<DeleteMessageBatchRequestEntry>(messages.Count);
+			var responseEntries = new List<SendMessageBatchRequestEntry>(messages.Count);
+			int i = 0;
+
+			foreach (Message message in messages) {
+				DumpAnalysisResponse result = null;
+
+				try {
+					result = ProcessMessage(message);
+				} catch (Exception e) {
+					Console.WriteLine(e);
+				}
+
+				if (result != null) {
+					responseEntries.Add(new SendMessageBatchRequestEntry(i.ToString(), JsonConvert.SerializeObject(result)));
+				}
+
+				deleteEntries.Add(new DeleteMessageBatchRequestEntry(i.ToString(), message.ReceiptHandle));
+				i++;
+			}
+
+			if (responseEntries.Count > 0) {
+				await sqsClient.SendMessageBatchAsync(new SendMessageBatchRequest(amazonSqsSettings.OutputQueueUrl, responseEntries));
+			}
+			if (deleteEntries.Count > 0) {
+				await sqsClient.DeleteMessageBatchAsync(new DeleteMessageBatchRequest(amazonSqsSettings.InputQueueUrl, deleteEntries));
+			}
+		}
+
+		/// <summary>
+		/// Processes a single message.
+		/// </summary>
+		/// <param name="message"></param>
+		/// <returns></returns>
+		private DumpAnalysisResponse ProcessMessage(Message message) {
+			AwsDumpAnalysisInput dumpInput = JsonConvert.DeserializeObject<AwsDumpAnalysisInput>(message.Body);
+			string bundleId = superDumpRepo.ProcessWebInputfile(dumpInput);
+
+			if (!string.IsNullOrEmpty(bundleId)) {
+				logger.LogSqsFileUpload(bundleId, dumpInput);
+				string url = new Uri(baseUri, linkGenerator.GetPathByAction(nameof(HomeController.BundleCreated), "Home", new { bundleId })).ToString();
+
+				return new DumpAnalysisResponse(dumpInput.SourceId, url);
+			} else {
+				logger.LogSqsInvalidUrl(dumpInput);
+				return null;
+			}
+		}
+	}
+}

--- a/src/SuperDumpService/Services/SuperDumpRepository.cs
+++ b/src/SuperDumpService/Services/SuperDumpRepository.cs
@@ -104,6 +104,18 @@ namespace SuperDumpService.Services {
 			}
 		}
 
+		public string ProcessWebInputfile(DumpAnalysisInput input) {
+			string filename = input.UrlFilename;
+			//validate URL
+			if (Utility.ValidateUrl(input.Url, ref filename)) {
+				if (filename == null && Utility.IsLocalFile(input.Url)) {
+					filename = Path.GetFileName(input.Url);
+				}
+				return ProcessWebInputfile(filename, input);
+			}
+			return string.Empty;
+		}
+
 		/// <summary>
 		/// create bundle, process the file
 		/// </summary>

--- a/src/SuperDumpService/SuperDumpService.csproj
+++ b/src/SuperDumpService/SuperDumpService.csproj
@@ -23,6 +23,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.Core" Version="3.3.103.71" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.102.38" />
     <PackageReference Include="Dynatrace.OneAgent.Sdk" Version="1.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.0.0" />

--- a/src/SuperDumpService/SuperDumpSettings.cs
+++ b/src/SuperDumpService/SuperDumpSettings.cs
@@ -43,6 +43,8 @@ namespace SuperDumpService {
 		public int DownloadServiceRetry { get; set; } = 3;
 		public int DownloadServiceRetryTimeout { get; set; } = 500;
 		public TimeSpan DownloadServiceHttpClientTimeout { get; set; } = TimeSpan.FromMinutes(4);
+		public bool UseAmazonSqs { get; set; }
+		public AmazonSqsSettings AmazonSqsSettings { get; set; }
 
 		public bool IsDumpRetentionEnabled () {
 			return !string.IsNullOrEmpty(DumpRetentionCron) && DumpRetentionDays > 0;


### PR DESCRIPTION
This PR adds support for Amazon SQS Queues.

The SuperDump service now checks periodically if a new message is in the input queue. After starting an analysis a link to the dump is sent to an output queue.