### PR TITLE
Fix archive extraction error handling

### DIFF
--- a/src/SuperDumpService/Helpers/SuperDumpLogExtension.cs
+++ b/src/SuperDumpService/Helpers/SuperDumpLogExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -93,6 +94,10 @@ namespace SuperDumpService.Helpers {
 
 		public static void LogSqsException(this ILogger logger, string messageBody, Exception ex) {
 			logger.LogInformation($"Exception while processing Amazon Sqs Message - Message: \"{messageBody}\" Exception: {ex.ToString()}");
+		}
+
+		public static void LogArchiveUnpackException(this ILogger logger, string bundleId, FileInfo file, Exception ex) {
+			logger.LogInformation($"Exception when extracting archive, bundleId: \"{bundleId}\", file: \"{file?.Name}\", exception: {ex.ToString()}");
 		}
 
 		private static string GetCustomPropertyString(IDictionary<string, string> customProperties) {

--- a/src/SuperDumpService/Services/JiraApiService.cs
+++ b/src/SuperDumpService/Services/JiraApiService.cs
@@ -100,7 +100,7 @@ namespace SuperDumpService.Services {
 
 		private bool ShallAuthenticate() {
 			// reauthenticate every 10 minutes
-			return Session == null || (DateTime.Now - Session.loginInfo.previousLoginTime).Minutes > 10;
+			return Session == null || Session.loginInfo == null || (DateTime.Now - Session.loginInfo.previousLoginTime).Minutes > 10;
 		}
 
 		public async Task<IEnumerable<JiraIssueModel>> GetJiraIssues(string bundleId) {

--- a/src/SuperDumpService/Services/SuperDumpRepository.cs
+++ b/src/SuperDumpService/Services/SuperDumpRepository.cs
@@ -157,7 +157,9 @@ namespace SuperDumpService.Services {
 
 		private async Task ProcessArchive(string bundleId, FileInfo archiveFile, ArchiveType type) {
 			DirectoryInfo dir = unpackService.ExtractArchive(archiveFile, type);
-			await ProcessDirRecursive(bundleId, dir);
+			if (dir != null) {
+				await ProcessDirRecursive(bundleId, dir);
+			}
 		}
 
 		private async Task IncludeOtherFiles(DirectoryInfo dir, DumpMetainfo dumpInfo, HashSet<string> foundPrimaryDumps) {

--- a/src/SuperDumpService/Services/SuperDumpRepository.cs
+++ b/src/SuperDumpService/Services/SuperDumpRepository.cs
@@ -18,6 +18,7 @@ using SuperDump.Models;
 using Dynatrace.OneAgent.Sdk.Api;
 using Dynatrace.OneAgent.Sdk.Api.Infos;
 using Dynatrace.OneAgent.Sdk.Api.Enums;
+using Microsoft.Extensions.Logging;
 
 namespace SuperDumpService.Services {
 	public class SuperDumpRepository {
@@ -35,6 +36,8 @@ namespace SuperDumpService.Services {
 		private readonly IOneAgentSdk dynatraceSdk;
 		private readonly IMessagingSystemInfo messagingSystemInfo;
 
+		private readonly ILogger<SuperDumpRepository> logger;
+
 		public SuperDumpRepository(
 				IOptions<SuperDumpSettings> settings,
 				BundleRepository bundleRepo,
@@ -45,7 +48,8 @@ namespace SuperDumpService.Services {
 				UnpackService unpackService,
 				PathHelper pathHelper,
 				IdenticalDumpRepository identicalRepository,
-				IOneAgentSdk dynatraceSdk) {
+				IOneAgentSdk dynatraceSdk,
+				ILoggerFactory loggerFactory) {
 			this.settings = settings;
 			this.bundleRepo = bundleRepo;
 			this.dumpRepo = dumpRepo;
@@ -59,6 +63,8 @@ namespace SuperDumpService.Services {
 
 			this.dynatraceSdk = dynatraceSdk;
 			messagingSystemInfo = dynatraceSdk.CreateMessagingSystemInfo("Hangfire", "download", MessageDestinationType.QUEUE, ChannelType.IN_PROCESS, null);
+
+			this.logger = loggerFactory.CreateLogger<SuperDumpRepository>();
 		}
 
 		public async Task<SDResult> GetResultAndThrow(DumpIdentifier id) {
@@ -156,7 +162,12 @@ namespace SuperDumpService.Services {
 		}
 
 		private async Task ProcessArchive(string bundleId, FileInfo archiveFile, ArchiveType type) {
-			DirectoryInfo dir = unpackService.ExtractArchive(archiveFile, type);
+			DirectoryInfo dir = null;
+			try {
+				dir = unpackService.ExtractArchive(archiveFile, type);
+			} catch (Exception e) {
+				logger.LogArchiveUnpackException(bundleId, archiveFile, e);
+			}
 			if (dir != null) {
 				await ProcessDirRecursive(bundleId, dir);
 			}

--- a/src/SuperDumpService/Services/UnpackService.cs
+++ b/src/SuperDumpService/Services/UnpackService.cs
@@ -47,19 +47,25 @@ namespace SuperDumpService.Services {
 		}
 
 		public DirectoryInfo ExtractArchive(FileInfo file, ArchiveType type) {
-			DirectoryInfo outputDir = FindUniqueTempDir(file.Directory, Path.GetFileNameWithoutExtension(file.Name));
-			switch (type) {
-				case ArchiveType.Zip:
-					ZipFile.ExtractToDirectory(file.FullName, outputDir.FullName);
-					break;
-				case ArchiveType.TarGz:
-					ExtractTarGz(file, outputDir);
-					break;
-				case ArchiveType.Tar:
-					ExtractTar(file, outputDir);
-					break;
+			try {
+				DirectoryInfo outputDir = FindUniqueTempDir(file.Directory, Path.GetFileNameWithoutExtension(file.Name));
+				switch (type) {
+					case ArchiveType.Zip:
+						ZipFile.ExtractToDirectory(file.FullName, outputDir.FullName);
+						break;
+					case ArchiveType.TarGz:
+						ExtractTarGz(file, outputDir);
+						break;
+					case ArchiveType.Tar:
+						ExtractTar(file, outputDir);
+						break;
+				}
+				return outputDir;
+			} catch (Exception e) {
+				Console.WriteLine($"Error extracting archive {file.Name}");
+				Console.WriteLine(e.ToString());
 			}
-			return outputDir;
+			return null;
 		}
 	}
 }

--- a/src/SuperDumpService/Services/UnpackService.cs
+++ b/src/SuperDumpService/Services/UnpackService.cs
@@ -47,25 +47,19 @@ namespace SuperDumpService.Services {
 		}
 
 		public DirectoryInfo ExtractArchive(FileInfo file, ArchiveType type) {
-			try {
-				DirectoryInfo outputDir = FindUniqueTempDir(file.Directory, Path.GetFileNameWithoutExtension(file.Name));
-				switch (type) {
-					case ArchiveType.Zip:
-						ZipFile.ExtractToDirectory(file.FullName, outputDir.FullName);
-						break;
-					case ArchiveType.TarGz:
-						ExtractTarGz(file, outputDir);
-						break;
-					case ArchiveType.Tar:
-						ExtractTar(file, outputDir);
-						break;
-				}
-				return outputDir;
-			} catch (Exception e) {
-				Console.WriteLine($"Error extracting archive {file.Name}");
-				Console.WriteLine(e.ToString());
+			DirectoryInfo outputDir = FindUniqueTempDir(file.Directory, Path.GetFileNameWithoutExtension(file.Name));
+			switch (type) {
+				case ArchiveType.Zip:
+					ZipFile.ExtractToDirectory(file.FullName, outputDir.FullName);
+					break;
+				case ArchiveType.TarGz:
+					ExtractTarGz(file, outputDir);
+					break;
+				case ArchiveType.Tar:
+					ExtractTar(file, outputDir);
+					break;
 			}
-			return null;
+			return outputDir;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes the problem that the whole analysis stops if an inner archive can't be opened/is corrupt.

Additionally, added a missing null check to the JiraApiService.