### PR TITLE
change dump analysis response json property names to lower case

### DIFF
--- a/src/SuperDumpService/Models/DumpAnalysisResponse.cs
+++ b/src/SuperDumpService/Models/DumpAnalysisResponse.cs
@@ -2,10 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace SuperDumpService.Models {
 	public class DumpAnalysisResponse {
+		[JsonProperty("sourceId")]
 		public string SourceId { get; }
+		[JsonProperty("superdumpUrl")]
 		public string SuperdumpUrl { get; }
 
 		public DumpAnalysisResponse(string sourceId, string superDumpUrl) {


### PR DESCRIPTION
Changed the json property names of the dump analysis response for the Amazon SQS queue to lower case.