### PR TITLE
improve download service logging

### DIFF
--- a/src/SuperDumpService/Helpers/SuperDumpLogExtension.cs
+++ b/src/SuperDumpService/Helpers/SuperDumpLogExtension.cs
@@ -100,6 +100,10 @@ namespace SuperDumpService.Helpers {
 			logger.LogInformation($"Exception when extracting archive, bundleId: \"{bundleId}\", file: \"{file?.Name}\", exception: {ex.ToString()}");
 		}
 
+		public static void LogDownloadException(this ILogger logger, string bundleId, string url, Exception ex) {
+			logger.LogInformation($"Exception in Download Service, bundleId: \"{bundleId}\", url: \"{url}\", exception: {ex.Message}");
+		}
+
 		private static string GetCustomPropertyString(IDictionary<string, string> customProperties) {
 			return string.Join(", ", customProperties.Select(entry => $"{entry.Key}: {entry.Value}"));
 		}

--- a/src/SuperDumpService/Services/DownloadService.cs
+++ b/src/SuperDumpService/Services/DownloadService.cs
@@ -4,6 +4,7 @@ using SuperDumpService.Models;
 using SuperDumpService.Helpers;
 using System.IO;
 using System.Net.Http;
+using Microsoft.Extensions.Logging;
 
 namespace SuperDumpService.Services {
 	public class DownloadService {
@@ -11,10 +12,12 @@ namespace SuperDumpService.Services {
 
 		private readonly PathHelper pathHelper;
 		private readonly IHttpClientFactory httpClientFactory;
+		private readonly ILogger<DownloadService> logger;
 
-		public DownloadService(PathHelper pathHelper, IHttpClientFactory httpClientFactory) {
+		public DownloadService(PathHelper pathHelper, IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory) {
 			this.pathHelper = pathHelper;
 			this.httpClientFactory = httpClientFactory;
+			logger = loggerFactory.CreateLogger<DownloadService>();
 		}
 
 		public async Task<TempFileHandle> Download(string bundleId, string url, string filename) {
@@ -41,7 +44,7 @@ namespace SuperDumpService.Services {
 						}
 					}
 				} catch(Exception e) {
-					Console.WriteLine($"Failed to download file from {url}. Deleting the download directory ...");
+					logger.LogDownloadException(bundleId, url, e);
 					dir.Delete(true);
 					throw e;
 				}


### PR DESCRIPTION
Added additional information to the log if a bundle download fails. The logging api is now used in this case instead of Console.WriteLine.