### PR TITLE
Fix Similarity Detection

### DIFF
--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -96,6 +96,11 @@ namespace SuperDumpService.Services {
 				dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Failed);
 			} else {
 				dumpRepo.SetDumpStatus(dumpInfo.Id, DumpStatus.Finished);
+
+				dumpInfo = dumpRepo.Get(dumpInfo.Id);
+				foreach(PostAnalysisJob job in analyzerPipeline.PostAnalysisJobs) {
+					job.AnalyzeDump(dumpInfo);
+				}
 			}
 
 			await notifications.NotifyDumpAnalysisFinished(dumpInfo);

--- a/src/SuperDumpService/Services/Analyzers/AnalyzerJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/AnalyzerJob.cs
@@ -42,4 +42,11 @@ namespace SuperDumpService.Services.Analyzers {
 	public abstract class InitalAnalyzerJob : AnalyzerJob {
 		public abstract Task<IEnumerable<DumpMetainfo>> CreateDumpInfos(string bundleId, DirectoryInfo directory);
 	}
+
+	/// <summary>
+	/// This analyzer steps depend on the sucessful analysis of previous steps. These steps are only executed if the main analyis was sucessful.
+	/// </summary>
+	public abstract class PostAnalysisJob {
+		public abstract void AnalyzeDump(DumpMetainfo dumpInfo);
+	}
 }

--- a/src/SuperDumpService/Services/Analyzers/AnalyzerPipeline.cs
+++ b/src/SuperDumpService/Services/Analyzers/AnalyzerPipeline.cs
@@ -10,6 +10,7 @@ namespace SuperDumpService.Services.Analyzers {
 	public class AnalyzerPipeline {
 		public IEnumerable<AnalyzerJob> Analyzers { get; private set; }
 		public IEnumerable<InitalAnalyzerJob> InitialAnalyzers { get; private set; }
+		public IEnumerable<PostAnalysisJob> PostAnalysisJobs { get; private set; }
 
 		public AnalyzerPipeline(
 					DumpRepository dumpRepo,
@@ -23,11 +24,14 @@ namespace SuperDumpService.Services.Analyzers {
 			var analyzers = new List<AnalyzerJob>();
 			analyzers.Add(new DumpAnalyzerJob(dumpRepo, settings, pathHelper, dynatraceSdk));
 			analyzers.Add(new EmptyAnalyzerJob(dumpRepo));
-			analyzers.Add(new ElasticSearchJob(bundleRepo, dumpRepo, elasticSearch));
-			analyzers.Add(new SimilarityAnalyzerJob(similarityService, settings));
+
+			var postAnalyzers = new List<PostAnalysisJob>();
+			postAnalyzers.Add(new ElasticSearchJob(bundleRepo, dumpRepo, elasticSearch));
+			postAnalyzers.Add(new SimilarityAnalyzerJob(similarityService, settings));
 
 			Analyzers = analyzers;
 			InitialAnalyzers = analyzers.Where(analyzerJob => analyzerJob is InitalAnalyzerJob).Cast<InitalAnalyzerJob>();
+			PostAnalysisJobs = postAnalyzers;
 		}
 	}
 }

--- a/src/SuperDumpService/Services/Analyzers/ElasticSearchJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/ElasticSearchJob.cs
@@ -4,7 +4,7 @@ using SuperDump.Models;
 using SuperDumpService.Models;
 
 namespace SuperDumpService.Services.Analyzers {
-	public class ElasticSearchJob : AnalyzerJob {
+	public class ElasticSearchJob : PostAnalysisJob {
 		private readonly BundleRepository bundleRepo;
 		private readonly DumpRepository dumpRepo;
 		private readonly ElasticSearchService elasticSearch;
@@ -15,11 +15,7 @@ namespace SuperDumpService.Services.Analyzers {
 			this.elasticSearch = elasticSearch;
 		}
 
-		public override async Task<AnalyzerState> AnalyzeDump(DumpMetainfo dumpInfo, string analysisWorkingDir, AnalyzerState previousState) {
-			if (previousState != AnalyzerState.Succeeded) {
-				return previousState;
-			}
-
+		public override async void AnalyzeDump(DumpMetainfo dumpInfo) {
 			BundleMetainfo bundle = bundleRepo.Get(dumpInfo.BundleId);
 			try {
 				SDResult result = await dumpRepo.GetResultAndThrow(dumpInfo.Id);
@@ -29,7 +25,6 @@ namespace SuperDumpService.Services.Analyzers {
 			} catch (Exception ex) {
 				Console.WriteLine(ex.Message);
 			}
-			return previousState;
 		}
 	}
 }

--- a/src/SuperDumpService/Services/Analyzers/SimilarityAnalyzerJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/SimilarityAnalyzerJob.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 using SuperDumpService.Models;
 
 namespace SuperDumpService.Services.Analyzers {
-	public class SimilarityAnalyzerJob : AnalyzerJob {
+	public class SimilarityAnalyzerJob : PostAnalysisJob {
 		private readonly SimilarityService similarityService;
 		private readonly IOptions<SuperDumpSettings> settings;
 
@@ -16,11 +16,8 @@ namespace SuperDumpService.Services.Analyzers {
 			this.settings = settings;
 		}
 
-		public override Task<AnalyzerState> AnalyzeDump(DumpMetainfo dumpInfo, string analysisWorkingDir, AnalyzerState previousState) {
-			if (previousState == AnalyzerState.Succeeded) {
-				similarityService.ScheduleSimilarityAnalysis(dumpInfo, false, DateTime.Now - TimeSpan.FromDays(settings.Value.SimilarityDetectionMaxDays));
-			}
-			return Task.FromResult(previousState);
+		public override void AnalyzeDump(DumpMetainfo dumpInfo) {
+			similarityService.ScheduleSimilarityAnalysis(dumpInfo, false, DateTime.Now - TimeSpan.FromDays(settings.Value.SimilarityDetectionMaxDays));
 		}
 	}
 }


### PR DESCRIPTION
The similarity detection did not work since the analysis service rework, since there is a check in the similarity analysis if the dump status is finished. However, this was only set after all analysis steps were finished, including the similarity analysis.

This PR adds post analysis steps, that are executed after the dump status was set correctly.