### PR TITLE
Fault Reporting

### DIFF
--- a/src/SuperDumpService.Test/FaultReportingTests.cs
+++ b/src/SuperDumpService.Test/FaultReportingTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using SuperDump.Models;
+using SuperDumpService.Models;
+using SuperDumpService.Services;
+using Xunit;
+
+namespace SuperDumpService.Test {
+	public class FaultReportingTests {
+
+		// .net managed exception, from bundleId=hqe1548&dumpId=mxc5990
+		[Fact]
+		public void TestFaultReporting1() {
+			var res1 = new SDResult { ThreadInformation = new Dictionary<uint, SDThread>() };
+			res1.ThreadInformation[1] = new SDThread(61) {
+				StackTrace = new SDCombinedStackTrace(new List<SDCombinedStackFrame>() {
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyErrorFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "app.dll", "MyAppFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "app.dll", "MyAppFrameB", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameB", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameC", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MySystemFrameA", 123, 456, 789, 1011, 1213, null),
+				}),
+				Index = 61,
+				EngineId = 61,
+				OsId = 18752,
+				LastException = new SDClrException() {
+					OSThreadId = 18752,
+					Type = null,
+					Message = "Could not load file or assembly 'Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified."
+				}
+			};
+			AddTagToFrameAndThread(res1, SDTag.NativeExceptionTag);
+
+			res1.LastEvent = new SDLastEvent("EXCEPTION", "CLR exception - code e0434352 (first/second chance not available)", 61);
+			var report = FaultReportCreator.CreateFaultReport(res1);
+
+			// test if expected pieces of data exist in report
+			Assert.NotNull(report.FaultReason);
+			Assert.Contains("EXCEPTION", report.FaultReason);
+			Assert.Contains("CLR exception - code e0434352", report.FaultReason);
+			Assert.Contains("Could not load file or assembly", report.FaultReason);
+
+			Assert.NotNull(report.FaultingFrames);
+			Assert.Equal(7, report.FaultingFrames.Count);
+		}
+
+		// native access violation, from bundleId=ygz3901&dumpId=maf2473
+		[Fact]
+		public void TestFaultReporting2() {
+			var res1 = new SDResult { ThreadInformation = new Dictionary<uint, SDThread>() };
+			res1.ThreadInformation[1] = new SDThread(39636) {
+				StackTrace = new SDCombinedStackTrace(new List<SDCombinedStackFrame>() {
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyErrorFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "app.dll", "MyAppFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "app.dll", "MyAppFrameB", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameB", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MyFrameworkFrameC", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.dll", "MySystemFrameA", 123, 456, 789, 1011, 1213, null),
+				}),
+				Index = 0,
+				EngineId = 0,
+				OsId = 39636
+			};
+			AddTagToFrameAndThread(res1, SDTag.NativeExceptionTag);
+
+			res1.LastEvent = new SDLastEvent("EXCEPTION", "Access violation - code c0000005 (first/second chance not available)", 0);
+			var report = FaultReportCreator.CreateFaultReport(res1);
+
+			// test if expected pieces of data exist in report
+			Assert.NotNull(report.FaultReason);
+			Assert.Contains("EXCEPTION", report.FaultReason);
+			Assert.Contains("Access violation - code c0000005 (first/second chance not available)", report.FaultReason);
+
+			Assert.NotNull(report.FaultingFrames);
+			Assert.Equal(7, report.FaultingFrames.Count);
+		}
+
+		// linux abort, from bundleId=fni4863&dumpId=ddm1365
+		[Fact]
+		public void TestFaultReporting3() {
+			var res1 = new SDResult { ThreadInformation = new Dictionary<uint, SDThread>() };
+			res1.ThreadInformation[1] = new SDThread(0) {
+				StackTrace = new SDCombinedStackTrace(new List<SDCombinedStackFrame>() {
+					new SDCombinedStackFrame(StackFrameType.Native, "libc-2.17.so", "MyErrorFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "libc-2.17.so", "MyAppFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "libc-2.17.so", "MyAppFrameB", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "libtux.so", "MyFrameworkFrameA", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "libtux.so", "MyFrameworkFrameB", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "ntdll.so", "MyFrameworkFrameC", 123, 456, 789, 1011, 1213, null),
+					new SDCombinedStackFrame(StackFrameType.Native, "srvsnl_mqha.so", "MySystemFrameA", 123, 456, 789, 1011, 1213, null),
+				}),
+				Index = 0,
+				EngineId = 0,
+				OsId = 0
+			};
+			
+			AddTagToFrameAndThread(res1, SDTag.NativeExceptionTag);
+
+			res1.LastEvent = new SDLastEvent {
+				Type = "6",
+				Description = "SIGABRT",
+				ThreadId = 0
+			};
+			var report = FaultReportCreator.CreateFaultReport(res1);
+
+			// test if expected pieces of data exist in report
+			Assert.NotNull(report.FaultReason);
+			Assert.Contains("SIGABRT", report.FaultReason);
+
+			Assert.NotNull(report.FaultingFrames);
+			Assert.Equal(7, report.FaultingFrames.Count);
+		}
+
+		[Fact]
+		public void TestFaultReportingLongStacktrace() {
+			var res1 = new SDResult { ThreadInformation = new Dictionary<uint, SDThread>() };
+
+			// Thread with 1000 stack frames
+			res1.ThreadInformation[1] = new SDThread(0) {
+				StackTrace = new SDCombinedStackTrace(
+					Enumerable.Repeat(new SDCombinedStackFrame(StackFrameType.Native, "lib.so", "MyErrorFrameA", 123, 456, 789, 1011, 1213, null), 1000).ToList()
+				),
+				Index = 0,
+				EngineId = 0,
+				OsId = 0
+			};
+
+			AddTagToFrameAndThread(res1, SDTag.NativeExceptionTag);
+
+			res1.LastEvent = new SDLastEvent {
+				Type = "6",
+				Description = "SIGABRT",
+				ThreadId = 0
+			};
+			var report = FaultReportCreator.CreateFaultReport(res1, 50); // maxFrames = 50
+
+			// test if long stacktrace is properly cut
+			Assert.NotNull(report.FaultingFrames);
+			Assert.Equal(50+1, report.FaultingFrames.Count); // only 50 frames allowed, plus 1 for "..."
+		}
+
+		private static void AddTagToFrameAndThread(SDResult result, SDTag tag) {
+			result.ThreadInformation[1].Tags.Add(tag);
+			result.ThreadInformation[1].StackTrace[0].Tags.Add(tag);
+		}
+
+		private class TestFaultReportSender : IFaultReportSender {
+			public List<FaultReport> Reports { get; private set; } = new List<FaultReport>();
+			
+			public Task SendFaultReport(DumpMetainfo dumpInfo, FaultReport faultReport) {
+				Reports.Add(faultReport);
+				return Task.CompletedTask;
+			}
+		}
+	}
+}

--- a/src/SuperDumpService/AmazonSqsSettings.cs
+++ b/src/SuperDumpService/AmazonSqsSettings.cs
@@ -12,6 +12,7 @@ namespace SuperDumpService {
 		public string Region { get; set; }
 		public string InputQueueUrl { get; set; }
 		public string OutputQueueUrl { get; set; }
+		public string FaultReportQueueUrl { get; set; }
 		public string AccessKey { get; set; }
 		public string SecretKey { get; set; }
 	}

--- a/src/SuperDumpService/Helpers/Utility.cs
+++ b/src/SuperDumpService/Helpers/Utility.cs
@@ -251,6 +251,19 @@ namespace SuperDumpService.Helpers {
 			}
 		}
 
+		/// <summary>
+		/// frames sometimes contain addresses. let's just strip out all non-ascii characters. comparison should still be valid enough.
+		/// even modules contain addresses in some cases. also lastevent or exception text.
+		/// </summary>
+		public static bool EqualsIgnoreNonAlphanumeric(string s1, string s2) {
+			if (s1 == null && s2 == null) return true;
+			if (s1 == null || s2 == null) return false;
+			return StripNonAlphanumeric(s1).Equals(StripNonAlphanumeric(s2), StringComparison.OrdinalIgnoreCase);
+		}
+
+		public static string StripNonAlphanumeric(string str) {
+			return str == null ? string.Empty : new string(str.ToLower().Where(c => c >= 'a' && c <= 'z').ToArray());
+		}
 	}
 
 	public static class StringExtensions {

--- a/src/SuperDumpService/Models/CrashSimilarity.cs
+++ b/src/SuperDumpService/Models/CrashSimilarity.cs
@@ -135,7 +135,7 @@ namespace SuperDumpService.Models {
 
 		// relative similarity between two strings
 		private static double StringSimilarity(string description1, string description2) {
-			return Utility.LevenshteinSimilarity(StripNonAscii(description1), StripNonAscii(description2));
+			return Utility.LevenshteinSimilarity(Utility.StripNonAlphanumeric(description1), Utility.StripNonAlphanumeric(description2));
 		}
 
 		private static double? CalculateExceptionMessageSimilarity(in DumpMiniInfo resultA, in DumpMiniInfo resultB) {
@@ -152,20 +152,6 @@ namespace SuperDumpService.Models {
 			// omit comparison of StackTrace for now. maybe implement at later point if it makes sense.
 		}
 
-		/// <summary>
-		/// frames sometimes contain addresses. let's just strip out all non-ascii characters. comparison should still be valid enough.
-		/// even modules contain addresses in some cases. also lastevent or exception text.
-		/// </summary>
-		private static bool EqualsIgnoreNonAscii(string s1, string s2) {
-			if (s1 == null && s2 == null) return true;
-			if (s1 == null || s2 == null) return false;
-			return StripNonAscii(s1).Equals(StripNonAscii(s2), StringComparison.OrdinalIgnoreCase);
-		}
-
-		private static string StripNonAscii(string str) {
-			return str == null ? string.Empty : new string(str.ToLower().Where(c => c >= 'a' && c <= 'z').ToArray());
-		}
-
 		public static DumpMiniInfo SDResultToMiniInfo(SDResult result) {
 			var miniinfo = new DumpMiniInfo();
 
@@ -173,8 +159,8 @@ namespace SuperDumpService.Models {
 			var faultingThread = result.GetErrorOrLastExecutingThread();
 			if (faultingThread != null) {
 				miniinfo.FaultingThread = new ThreadMiniInfo() {
-					DistinctModuleHashes = faultingThread.StackTrace.Select(x => StripNonAscii(x.ModuleName).GetStableHashCode()).Distinct().ToArray(),
-					DistinctFrameHashes = faultingThread.StackTrace.Select(x => StripNonAscii(x.MethodName).GetStableHashCode()).Distinct().ToArray()
+					DistinctModuleHashes = faultingThread.StackTrace.Select(x => Utility.StripNonAlphanumeric(x.ModuleName).GetStableHashCode()).Distinct().ToArray(),
+					DistinctFrameHashes = faultingThread.StackTrace.Select(x => Utility.StripNonAlphanumeric(x.MethodName).GetStableHashCode()).Distinct().ToArray()
 				};
 			}
 

--- a/src/SuperDumpService/Models/InputModel.cs
+++ b/src/SuperDumpService/Models/InputModel.cs
@@ -45,6 +45,9 @@ namespace SuperDumpService.Models {
 		/// <summary>
 		/// This Id is used to correlate the dump input with the response that the dump was created.
 		/// </summary>
-		public string SourceId { get; set; }
+		public string SourceId {
+			get => CustomProperties["sourceId"];
+			set => CustomProperties["sourceId"] = value;
+		}
 	}
 }

--- a/src/SuperDumpService/Services/AmazonSqsClientService.cs
+++ b/src/SuperDumpService/Services/AmazonSqsClientService.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Hangfire;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using SuperDumpService.Controllers;
+using SuperDumpService.Helpers;
+using SuperDumpService.Models;
+
+namespace SuperDumpService.Services {
+	public class AmazonSqsClientService {
+		private readonly AmazonSqsSettings amazonSqsSettings;
+		public IAmazonSQS SqsClient { get; }
+
+		public AmazonSqsClientService(IOptions<SuperDumpSettings> settings) {
+			this.amazonSqsSettings = settings.Value.AmazonSqsSettings;
+			var credentials = new BasicAWSCredentials(amazonSqsSettings.AccessKey, amazonSqsSettings.SecretKey);
+			var config = new AmazonSQSConfig {
+				RegionEndpoint = RegionEndpoint.GetBySystemName(amazonSqsSettings.Region)
+			};
+			this.SqsClient = new AmazonSQSClient(credentials, config);
+		}
+	}
+}

--- a/src/SuperDumpService/Services/AmazonSqsFaultReportingSender.cs
+++ b/src/SuperDumpService/Services/AmazonSqsFaultReportingSender.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Hangfire;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using SuperDumpService.Controllers;
+using SuperDumpService.Helpers;
+using SuperDumpService.Models;
+
+namespace SuperDumpService.Services {
+	public class AmazonSqsFaultReportingSender : IFaultReportSender {
+		private readonly AmazonSqsSettings amazonSqsSettings;
+		private readonly AmazonSqsClientService amazonSqsClientService;
+		private readonly ILogger<AmazonSqsFaultReportingSender> logger;
+
+		public AmazonSqsFaultReportingSender(
+				IOptions<SuperDumpSettings> settings,
+				AmazonSqsClientService amazonSqsClientService,
+				ILoggerFactory loggerFactory
+			) {
+			this.amazonSqsSettings = settings.Value.AmazonSqsSettings;
+			this.amazonSqsClientService = amazonSqsClientService;
+			this.logger = loggerFactory.CreateLogger<AmazonSqsFaultReportingSender>();
+		}
+
+		public async Task SendFaultReport(DumpMetainfo dumpInfo, FaultReport faultReport) {
+			var faultReportJson = JsonConvert.SerializeObject(faultReport);
+			logger.LogInformation($"Sending to {amazonSqsSettings.FaultReportQueueUrl}: \n{faultReportJson}");
+			var messageRequest = new SendMessageRequest(amazonSqsSettings.FaultReportQueueUrl, faultReportJson);
+			await amazonSqsClientService.SqsClient.SendMessageAsync(messageRequest);
+		}
+	}
+}

--- a/src/SuperDumpService/Services/AmazonSqsPollingService.cs
+++ b/src/SuperDumpService/Services/AmazonSqsPollingService.cs
@@ -17,27 +17,26 @@ using SuperDumpService.Helpers;
 using SuperDumpService.Models;
 
 namespace SuperDumpService.Services {
-	public class AmazonSqsService : IFaultReportSender {
+	public class AmazonSqsPollingService {
 		private readonly AmazonSqsSettings amazonSqsSettings;
-		private readonly IAmazonSQS sqsClient;
 		private readonly SuperDumpRepository superDumpRepo;
+		private readonly AmazonSqsClientService amazonSqsClientService;
 		private readonly LinkGenerator linkGenerator;
-		private readonly ILogger<AmazonSqsService> logger;
+		private readonly ILogger<AmazonSqsPollingService> logger;
 		private readonly Uri baseUri;
 
-		public AmazonSqsService(IOptions<SuperDumpSettings> settings, SuperDumpRepository superDumpRepo, LinkGenerator linkGenerator, ILoggerFactory loggerFactory) {
+		public AmazonSqsPollingService(
+				IOptions<SuperDumpSettings> settings,
+				SuperDumpRepository superDumpRepo,
+				AmazonSqsClientService amazonSqsClientService,
+				LinkGenerator linkGenerator, 
+				ILoggerFactory loggerFactory
+			) {
 			this.amazonSqsSettings = settings.Value.AmazonSqsSettings;
 			this.superDumpRepo = superDumpRepo;
+			this.amazonSqsClientService = amazonSqsClientService;
 			this.linkGenerator = linkGenerator;
-
-			this.logger = loggerFactory.CreateLogger<AmazonSqsService>();
-
-			var credentials = new BasicAWSCredentials(amazonSqsSettings.AccessKey, amazonSqsSettings.SecretKey);
-			var config = new AmazonSQSConfig {
-				RegionEndpoint = RegionEndpoint.GetBySystemName(amazonSqsSettings.Region)
-			};
-			this.sqsClient = new AmazonSQSClient(credentials, config);
-
+			this.logger = loggerFactory.CreateLogger<AmazonSqsPollingService>();
 			this.baseUri = new Uri(amazonSqsSettings.SuperDumpBaseUrl);
 		}
 
@@ -60,7 +59,7 @@ namespace SuperDumpService.Services {
 			int received;
 
 			do {
-				ReceiveMessageResponse response = await sqsClient.ReceiveMessageAsync(request);
+				ReceiveMessageResponse response = await amazonSqsClientService.SqsClient.ReceiveMessageAsync(request);
 
 				received = response.Messages.Count;
 
@@ -102,10 +101,10 @@ namespace SuperDumpService.Services {
 			}
 
 			if (responseEntries.Count > 0) {
-				await sqsClient.SendMessageBatchAsync(new SendMessageBatchRequest(amazonSqsSettings.OutputQueueUrl, responseEntries));
+				await amazonSqsClientService.SqsClient.SendMessageBatchAsync(new SendMessageBatchRequest(amazonSqsSettings.OutputQueueUrl, responseEntries));
 			}
 			if (deleteEntries.Count > 0) {
-				await sqsClient.DeleteMessageBatchAsync(new DeleteMessageBatchRequest(amazonSqsSettings.InputQueueUrl, deleteEntries));
+				await amazonSqsClientService.SqsClient.DeleteMessageBatchAsync(new DeleteMessageBatchRequest(amazonSqsSettings.InputQueueUrl, deleteEntries));
 			}
 		}
 
@@ -127,10 +126,6 @@ namespace SuperDumpService.Services {
 				logger.LogSqsInvalidUrl(dumpInput);
 				return null;
 			}
-		}
-
-		public async Task SendFaultReport(DumpMetainfo dumpInfo, FaultReport faultReport) {
-			Console.WriteLine("SendFaultReport " + faultReport.ToString());
 		}
 	}
 }

--- a/src/SuperDumpService/Services/AmazonSqsService.cs
+++ b/src/SuperDumpService/Services/AmazonSqsService.cs
@@ -129,7 +129,7 @@ namespace SuperDumpService.Services {
 			}
 		}
 
-		public async Task SendFaultReport(FaultReport faultReport) {
+		public async Task SendFaultReport(DumpMetainfo dumpInfo, FaultReport faultReport) {
 			Console.WriteLine("SendFaultReport " + faultReport.ToString());
 		}
 	}

--- a/src/SuperDumpService/Services/AmazonSqsService.cs
+++ b/src/SuperDumpService/Services/AmazonSqsService.cs
@@ -17,7 +17,7 @@ using SuperDumpService.Helpers;
 using SuperDumpService.Models;
 
 namespace SuperDumpService.Services {
-	public class AmazonSqsService {
+	public class AmazonSqsService : IFaultReportSender {
 		private readonly AmazonSqsSettings amazonSqsSettings;
 		private readonly IAmazonSQS sqsClient;
 		private readonly SuperDumpRepository superDumpRepo;
@@ -127,6 +127,10 @@ namespace SuperDumpService.Services {
 				logger.LogSqsInvalidUrl(dumpInput);
 				return null;
 			}
+		}
+
+		public async Task SendFaultReport(FaultReport faultReport) {
+			Console.WriteLine("SendFaultReport " + faultReport.ToString());
 		}
 	}
 }

--- a/src/SuperDumpService/Services/AnalysisService.cs
+++ b/src/SuperDumpService/Services/AnalysisService.cs
@@ -99,7 +99,7 @@ namespace SuperDumpService.Services {
 
 				dumpInfo = dumpRepo.Get(dumpInfo.Id);
 				foreach(PostAnalysisJob job in analyzerPipeline.PostAnalysisJobs) {
-					job.AnalyzeDump(dumpInfo);
+					await job.AnalyzeDump(dumpInfo);
 				}
 			}
 

--- a/src/SuperDumpService/Services/Analyzers/AnalyzerJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/AnalyzerJob.cs
@@ -47,6 +47,6 @@ namespace SuperDumpService.Services.Analyzers {
 	/// This analyzer steps depend on the sucessful analysis of previous steps. These steps are only executed if the main analyis was sucessful.
 	/// </summary>
 	public abstract class PostAnalysisJob {
-		public abstract void AnalyzeDump(DumpMetainfo dumpInfo);
+		public abstract Task AnalyzeDump(DumpMetainfo dumpInfo);
 	}
 }

--- a/src/SuperDumpService/Services/Analyzers/AnalyzerPipeline.cs
+++ b/src/SuperDumpService/Services/Analyzers/AnalyzerPipeline.cs
@@ -19,6 +19,7 @@ namespace SuperDumpService.Services.Analyzers {
 					IOptions<SuperDumpSettings> settings,
 					ElasticSearchService elasticSearch,
 					SimilarityService similarityService,
+					FaultReportingService faultReportingService,
 					IOneAgentSdk dynatraceSdk) {
 
 			var analyzers = new List<AnalyzerJob>();
@@ -28,6 +29,7 @@ namespace SuperDumpService.Services.Analyzers {
 			var postAnalyzers = new List<PostAnalysisJob>();
 			postAnalyzers.Add(new ElasticSearchJob(bundleRepo, dumpRepo, elasticSearch));
 			postAnalyzers.Add(new SimilarityAnalyzerJob(similarityService, settings));
+			postAnalyzers.Add(new FaultReportJob(faultReportingService, settings));
 
 			Analyzers = analyzers;
 			InitialAnalyzers = analyzers.Where(analyzerJob => analyzerJob is InitalAnalyzerJob).Cast<InitalAnalyzerJob>();

--- a/src/SuperDumpService/Services/Analyzers/ElasticSearchJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/ElasticSearchJob.cs
@@ -15,7 +15,7 @@ namespace SuperDumpService.Services.Analyzers {
 			this.elasticSearch = elasticSearch;
 		}
 
-		public override async void AnalyzeDump(DumpMetainfo dumpInfo) {
+		public override async Task AnalyzeDump(DumpMetainfo dumpInfo) {
 			BundleMetainfo bundle = bundleRepo.Get(dumpInfo.BundleId);
 			try {
 				SDResult result = await dumpRepo.GetResultAndThrow(dumpInfo.Id);

--- a/src/SuperDumpService/Services/Analyzers/FaultReportJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/FaultReportJob.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using SuperDumpService.Models;
+
+namespace SuperDumpService.Services.Analyzers {
+	public class FaultReportJob : PostAnalysisJob {
+		private readonly FaultReportingService faultReportingService;
+		private readonly IOptions<SuperDumpSettings> settings;
+
+		public FaultReportJob(FaultReportingService faultReportingService, IOptions<SuperDumpSettings> settings) {
+			this.faultReportingService = faultReportingService;
+			this.settings = settings;
+		}
+
+		public override async Task AnalyzeDump(DumpMetainfo dumpInfo) {
+			await faultReportingService.PublishFaultReport(dumpInfo);
+		}
+	}
+}

--- a/src/SuperDumpService/Services/Analyzers/SimilarityAnalyzerJob.cs
+++ b/src/SuperDumpService/Services/Analyzers/SimilarityAnalyzerJob.cs
@@ -16,7 +16,7 @@ namespace SuperDumpService.Services.Analyzers {
 			this.settings = settings;
 		}
 
-		public override void AnalyzeDump(DumpMetainfo dumpInfo) {
+		public override async Task AnalyzeDump(DumpMetainfo dumpInfo) {
 			similarityService.ScheduleSimilarityAnalysis(dumpInfo, false, DateTime.Now - TimeSpan.FromDays(settings.Value.SimilarityDetectionMaxDays));
 		}
 	}

--- a/src/SuperDumpService/Services/FaultReportingService.cs
+++ b/src/SuperDumpService/Services/FaultReportingService.cs
@@ -26,7 +26,8 @@ namespace SuperDumpService.Services {
 		public async Task PublishFaultReport(DumpMetainfo dumpInfo) {
 			var result = await dumpRepository.GetResult(dumpInfo.Id);
 			var faultReport = FaultReportCreator.CreateFaultReport(result);
-			faultReport.SourceId = bundleRepository.Get(dumpInfo.BundleId).CustomProperties["sourceId"];
+			var bundleInfo = bundleRepository.Get(dumpInfo.BundleId);
+			if (bundleInfo.CustomProperties.ContainsKey("sourceId")) faultReport.SourceId = bundleRepository.Get(dumpInfo.BundleId).CustomProperties["sourceId"];
 			await faultReportSender.SendFaultReport(dumpInfo, faultReport);
 		}
 	}

--- a/src/SuperDumpService/Services/FaultReportingService.cs
+++ b/src/SuperDumpService/Services/FaultReportingService.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using SuperDumpService.Models;
+
+namespace SuperDumpService.Services {
+	/// <summary>
+	/// This service creates a report from a crash dump, that is supposed to identify it well enough to be able to detect identical crashes (deduplication).
+	/// The report is supposed to be consumed by an expternal service, not by SuperDump itself.
+	/// </summary>
+	public class FaultReportingService {
+		private readonly IFaultReportSender faultReportSender;
+
+		public FaultReportingService(IFaultReportSender faultReportSender) {
+			this.faultReportSender = faultReportSender;
+		}
+
+		public async Task PublishFaultReport(DumpMetainfo dumpInfo) {
+			var faultReport = CreateFaultReport(dumpInfo);
+			await faultReportSender.SendFaultReport(faultReport);
+		}
+
+		private FaultReport CreateFaultReport(DumpMetainfo dumpInfo) {
+			return new FaultReport(dumpInfo);
+		}
+	}
+
+	public class FaultReport {
+		private DumpMetainfo dumpInfo;
+
+		public FaultReport(DumpMetainfo dumpInfo) {
+			this.dumpInfo = dumpInfo;
+		}
+
+		public override string ToString() {
+			return dumpInfo.ToString();
+		}
+	}
+
+	/// <summary>
+	/// A dummy FaultReport sender, in case no other sender is registered.
+	/// </summary>
+	public class ConsoleFaultReportingSender : IFaultReportSender {
+		public async Task SendFaultReport(FaultReport faultReport) {
+			Console.WriteLine(faultReport.ToString());
+		}
+	}
+}

--- a/src/SuperDumpService/Services/FaultReportingService.cs
+++ b/src/SuperDumpService/Services/FaultReportingService.cs
@@ -89,8 +89,10 @@ namespace SuperDumpService.Services {
 		}
 	}
 
+	/// <summary>
+	/// A FaultReport is supposed to be a concise summary of the crash reason. Human readable.
+	/// </summary>
 	public class FaultReport {
-
 		public string FaultReason { get; set; }
 		public string FaultLocation { get; set; }
 		public string FaultModulePath { get; set; }

--- a/src/SuperDumpService/Services/IFaultReportSender.cs
+++ b/src/SuperDumpService/Services/IFaultReportSender.cs
@@ -1,0 +1,7 @@
+﻿using System.Threading.Tasks;
+
+namespace SuperDumpService.Services {
+	public interface IFaultReportSender {
+		Task SendFaultReport(FaultReport faultReport);
+	}
+}

--- a/src/SuperDumpService/Services/IFaultReportSender.cs
+++ b/src/SuperDumpService/Services/IFaultReportSender.cs
@@ -1,7 +1,8 @@
 ﻿using System.Threading.Tasks;
+using SuperDumpService.Models;
 
 namespace SuperDumpService.Services {
 	public interface IFaultReportSender {
-		Task SendFaultReport(FaultReport faultReport);
+		Task SendFaultReport(DumpMetainfo dumpInfo, FaultReport faultReport);
 	}
 }

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -166,6 +166,13 @@ namespace SuperDumpService {
 			if (superDumpSettings.UseAmazonSqs) {
 				services.AddSingleton<AmazonSqsService>();
 			}
+
+			if (superDumpSettings.UseAmazonSqs) {
+				services.AddSingleton<IFaultReportSender, AmazonSqsService>();
+			} else {
+				services.AddSingleton<IFaultReportSender, ConsoleFaultReportingSender>();
+			}
+			services.AddSingleton<FaultReportingService>();
 			
 			var sdk = OneAgentSdkFactory.CreateInstance();
 			sdk.SetLoggingCallback(new DynatraceSdkLogger(services.BuildServiceProvider().GetService<ILogger<DynatraceSdkLogger>>()));

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -164,11 +164,12 @@ namespace SuperDumpService {
 			services.AddSingleton<JiraIssueRepository>();
 			services.AddSingleton<SearchService>();
 			if (superDumpSettings.UseAmazonSqs) {
-				services.AddSingleton<AmazonSqsService>();
+				services.AddSingleton<AmazonSqsClientService>();
+				services.AddSingleton<AmazonSqsPollingService>();
 			}
 
 			if (superDumpSettings.UseAmazonSqs) {
-				services.AddSingleton<IFaultReportSender, AmazonSqsService>();
+				services.AddSingleton<IFaultReportSender, AmazonSqsFaultReportingSender>();
 			} else {
 				services.AddSingleton<IFaultReportSender, ConsoleFaultReportSender>();
 			}
@@ -263,7 +264,7 @@ namespace SuperDumpService {
 					Queues = new[] { "amazon-sqs-poll" },
 					WorkerCount = 2
 				});
-				AmazonSqsService amazonSqsService = app.ApplicationServices.GetService<AmazonSqsService>();
+				AmazonSqsPollingService amazonSqsService = app.ApplicationServices.GetService<AmazonSqsPollingService>();
 				amazonSqsService.StartHangfireJob();
 			}
 

--- a/src/SuperDumpService/Startup.cs
+++ b/src/SuperDumpService/Startup.cs
@@ -170,7 +170,7 @@ namespace SuperDumpService {
 			if (superDumpSettings.UseAmazonSqs) {
 				services.AddSingleton<IFaultReportSender, AmazonSqsService>();
 			} else {
-				services.AddSingleton<IFaultReportSender, ConsoleFaultReportingSender>();
+				services.AddSingleton<IFaultReportSender, ConsoleFaultReportSender>();
 			}
 			services.AddSingleton<FaultReportingService>();
 			


### PR DESCRIPTION
With this feature, SuperDump can report the result of a dump analysis as a message to a queue. Currently only Amazon SQS is implemented.

The goal is that another system can use this qualified analysis to display more information and possibly use it to for deduplication.