### PR TITLE
Simplify uris

### DIFF
--- a/src/SuperDumpService/Helpers/Utility.cs
+++ b/src/SuperDumpService/Helpers/Utility.cs
@@ -264,6 +264,10 @@ namespace SuperDumpService.Helpers {
 		public static string StripNonAlphanumeric(string str) {
 			return str == null ? string.Empty : new string(str.ToLower().Where(c => c >= 'a' && c <= 'z').ToArray());
 		}
+
+		public static string GetDumpUrl(DumpIdentifier id) {
+			return $"/Home/Dump?id={id}";
+		}
 	}
 
 	public static class StringExtensions {

--- a/src/SuperDumpService/Models/DumpIdentifier.cs
+++ b/src/SuperDumpService/Models/DumpIdentifier.cs
@@ -17,6 +17,14 @@ namespace SuperDumpService.Models {
 
 		public static DumpIdentifier Create(string bundleId, string dumpId) => pool.Allocate(bundleId, dumpId);
 
+		public static DumpIdentifier Parse(string id) {
+			if (id == null) return null;
+			if (!id.Contains(":")) return null;
+			var parts = id.Split(":");
+			if (parts.Length != 2) return null;
+			return Create(parts[0], parts[1]);
+		}
+
 		public bool Equals(DumpIdentifier other) { // for IEquatable<Pair>
 			return Equals(BundleId, other.BundleId) && Equals(DumpId, other.DumpId);
 		}

--- a/src/SuperDumpService/Services/SlackNotificationService.cs
+++ b/src/SuperDumpService/Services/SlackNotificationService.cs
@@ -12,6 +12,7 @@ using SuperDump.Models;
 using RazorLight;
 using SuperDumpService.ViewModels;
 using System.IO;
+using SuperDumpService.Helpers;
 
 namespace SuperDumpService.Services {
 	public class SlackNotificationService {
@@ -55,7 +56,7 @@ namespace SuperDumpService.Services {
 
 			model.TopProperties.Add(dumpInfo.DumpType == DumpType.WindowsDump ? "Windows" : "Linux");
 			model.DumpFilename = Path.GetFileName(dumpInfo.DumpFileName);
-			model.Url = $"{superDumpUrl}/Home/Report?bundleId={dumpInfo.BundleId}&dumpId={dumpInfo.DumpId}";
+			model.Url = $"{superDumpUrl}{Utility.GetDumpUrl(dumpInfo.Id)}";
 			if (res != null) {
 				if (res.SystemContext != null) {
 					model.TopProperties.Add(res.SystemContext.ProcessArchitecture);

--- a/src/SuperDumpService/Views/Home/BundleCreated.cshtml
+++ b/src/SuperDumpService/Views/Home/BundleCreated.cshtml
@@ -23,17 +23,17 @@
 	} else if (Model.DumpInfos.Count() == 1) {
 		var item = Model.DumpInfos.First();
 		<h3>
-		Dump with id <strong><a asp-controller="Home" asp-action="Report" asp-route-bundleId="@item.DumpInfo.BundleId" asp-route-dumpId="@item.DumpInfo.DumpId">@item.DumpInfo.DumpId</a></strong> successfully created.</h3>
+		Dump with id <strong><a href="@SuperDumpService.Helpers.Utility.GetDumpUrl(item.DumpInfo.Id)">@item.DumpInfo.DumpId</a></strong> successfully created.</h3>
 
 		<p>You'll be redirected to the report...</p>
 		<script>
-			window.location.replace("/Home/Report?bundleId=@item.DumpInfo.BundleId&dumpId=@item.DumpInfo.DumpId");
+			window.location.replace("@SuperDumpService.Helpers.Utility.GetDumpUrl(item.DumpInfo.Id)");
 		</script>
 	} else {
 		<h3>You uploaded a zip file with several dumps.</h3>
 		<ul>
 			@foreach (var item in Model.DumpInfos) {
-				<li><strong><a asp-controller="Home" asp-action="Report" asp-route-bundleId="@item.DumpInfo.BundleId" asp-route-dumpId="@item.DumpInfo.DumpId">@item.DumpInfo.DumpId (@System.IO.Path.GetFileName(item.DumpInfo.DumpFileName))</a></strong> successfully created.</li>
+				<li><strong><a href="@SuperDumpService.Helpers.Utility.GetDumpUrl(item.DumpInfo.Id)">@item.DumpInfo.DumpId (@System.IO.Path.GetFileName(item.DumpInfo.DumpFileName))</a></strong> successfully created.</li>
 			}
 		</ul>
 	}

--- a/src/SuperDumpService/Views/Home/Dumps.cshtml
+++ b/src/SuperDumpService/Views/Home/Dumps.cshtml
@@ -82,7 +82,7 @@
 	}
 	<p>Showing @Model.Filtered.Count() dumps.
 		@if (ViewData["duplBundleId"] != null) {
-			<span>(duplicates of <a asp-controller="Home" asp-action="Report" asp-route-bundleId="@ViewData["duplBundleId"]" asp-route-dumpId="@ViewData["duplDumpId"]">@ViewData["duplBundleId"]:@ViewData["duplDumpId"]</a>)</span>
+			<span>(duplicates of <a href="@SuperDumpService.Helpers.Utility.GetDumpUrl(SuperDumpService.Models.DumpIdentifier.Create(ViewData["duplBundleId"].ToString(), ViewData["duplDumpId"].ToString()))">@ViewData["duplBundleId"]:@ViewData["duplDumpId"]</a>)</span>
 		}
 	</p>
 	<div class="panel-body">

--- a/src/SuperDumpService/Views/Home/Interactive.cshtml
+++ b/src/SuperDumpService/Views/Home/Interactive.cshtml
@@ -26,7 +26,7 @@
 	<div class="container-webterm" style="padding-top: 50px;">
 		<div style="display:inline-block; float: left; padding: 8px;">
 			Interactive debug session for <strong>@Model.DumpInfo.DumpFileName</strong>.
-			<a asp-controller="Home" asp-action="Report" asp-route-bundleId="@Model.Id.BundleId" asp-route-dumpId="@Model.Id.DumpId">Back to Report</a>
+			<a href="@SuperDumpService.Helpers.Utility.GetDumpUrl(Model.Id)">Back to Report</a>
 		</div>
 		<div style="display:inline-block; float: right; padding: 8px;">
 			<a href="http://windbg.info/doc/1-common-cmds.html">WinDbg Cheat Sheet</a>

--- a/src/SuperDumpService/Views/Home/Report.cshtml
+++ b/src/SuperDumpService/Views/Home/Report.cshtml
@@ -79,7 +79,7 @@
 												<a asp-controller="Similarity" asp-action="CompareDumps" asp-route-bundleId1="@Model.Id.BundleId" asp-route-dumpId1="@Model.Id.DumpId" asp-route-bundleId2="@rel.Key.Id.BundleId" asp-route-dumpId2="@rel.Key.Id.DumpId">
 													<span class="font-weight-bold text-success">@Math.Round(rel.Value * 100.0, 0)&#37;</span>
 												</a>
-												<a asp-controller="Home" asp-action="Report" asp-route-bundleId="@rel.Key.BundleId" asp-route-dumpId="@rel.Key.DumpId">@System.IO.Path.GetFileName(rel.Key.DumpFileName)</a>
+												<a href="@SuperDumpService.Helpers.Utility.GetDumpUrl(rel.Key.Id)">@System.IO.Path.GetFileName(rel.Key.DumpFileName)</a>
 												@if (Model.UseJiraIntegration && Model.SimilarDumpIssues.TryGetValue(rel.Key.BundleId, out IEnumerable<JiraIssueModel> issues)) {
 													<div class="mt-2 small">
 														<partial class="col-sm-8" id="duplicateJiraIssues" name="_JiraIssues" model="issues" />

--- a/src/SuperDumpService/Views/Home/Rerun.cshtml
+++ b/src/SuperDumpService/Views/Home/Rerun.cshtml
@@ -6,6 +6,6 @@
 <p>You'll be redirected to the report in 3 seconds...</p>
 <script>
 	setTimeout(function () {
-		window.location.replace("/Home/Report?bundleId=@Model.Id.BundleId&dumpId=@Model.Id.DumpId");
+		window.location.replace(@SuperDumpService.Helpers.Utility.GetDumpUrl(Model.Id));
 	}, 3000);
 </script>

--- a/src/SuperDumpService/Views/Home/Rerun.cshtml
+++ b/src/SuperDumpService/Views/Home/Rerun.cshtml
@@ -6,6 +6,6 @@
 <p>You'll be redirected to the report in 3 seconds...</p>
 <script>
 	setTimeout(function () {
-		window.location.replace(@SuperDumpService.Helpers.Utility.GetDumpUrl(Model.Id));
+		window.location.replace("@SuperDumpService.Helpers.Utility.GetDumpUrl(Model.Id)");
 	}, 3000);
 </script>

--- a/src/SuperDumpService/Views/Home/_DumpList.cshtml
+++ b/src/SuperDumpService/Views/Home/_DumpList.cshtml
@@ -16,10 +16,9 @@
 		@foreach (var dump in @Model.Paged.OrderByDescending(dump => dump.DumpInfo.Created)) {
 			<tr>
 				<td>
-
-					<a asp-controller="Home" asp-action="Report" asp-route-bundleId="@dump.DumpInfo.BundleId" asp-route-dumpId="@dump.DumpInfo.DumpId">
+					<a href="@SuperDumpService.Helpers.Utility.GetDumpUrl(dump.DumpInfo.Id)">
 						@(string.IsNullOrEmpty(dump.DumpInfo.DumpFileName) ? "Empty Dump" : System.IO.Path.GetFileName(dump.DumpInfo.DumpFileName))
-					</a> 
+					</a>
 					<span class="text-muted">(@dump.DumpInfo.BundleId:@dump.DumpInfo.DumpId)</span>
 					@if (dump.DumpInfo.Status != SuperDumpService.Models.DumpStatus.Finished) {
 						<span>(@dump.DumpInfo.Status)</span>

--- a/src/SuperDumpService/Views/Similarity/CompareDumps.cshtml
+++ b/src/SuperDumpService/Views/Similarity/CompareDumps.cshtml
@@ -8,7 +8,7 @@
 } else {
 
 	<h3>Compare Dumps</h3>
-	<p>Compared <a asp-controller="Home" asp-action="Report" asp-route-bundleId="@Model.DumpA.BundleId" asp-route-dumpId="@Model.DumpA.DumpId">@Model.DumpA</a> with <a asp-controller="Home" asp-action="Report" asp-route-bundleId="@Model.DumpB.BundleId" asp-route-dumpId="@Model.DumpB.DumpId">@Model.DumpB</a>.</p>
+	<p>Compared <a href="@SuperDumpService.Helpers.Utility.GetDumpUrl(Model.DumpA)">@Model.DumpA</a> with <a href="@SuperDumpService.Helpers.Utility.GetDumpUrl(Model.DumpB)">@Model.DumpB</a>.</p>
 
 	<dl class="row compact">
 		<dt class="col-sm-3 text-right">Overall (average)</dt>


### PR DESCRIPTION
Uri simplification for convenience.

Show dump:
old: http://localhost:5000/Home/Report?bundleId=lze0821&dumpId=gtc0647
new: http://localhost:5000/Home/Dump?id=lze0821:gtc0647

It's shorter and the dump identifier is easier to copy. The old URI still works.