### PR TITLE
Change Visual Studio version back to professional

### DIFF
--- a/building/build.cmd
+++ b/building/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 cd /d %~dp0
 
-set MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\amd64\MSBuild.exe"
+set MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\amd64\MSBuild.exe"
 set target="Windows"
 if not "%1" == "" ( set target="%1" )
 

--- a/src/SuperDump.Analyzer.Linux/SuperDump.Analyzer.Linux.csproj
+++ b/src/SuperDump.Analyzer.Linux/SuperDump.Analyzer.Linux.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="sharpcompress" Version="0.22.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Thinktecture.Abstractions" Version="2.4.0" />


### PR DESCRIPTION
Changes the MSBuild path back to the Visual Studio Professional path instead of Preview.

Also fixes a package downgrade build error